### PR TITLE
Allow stecman/symfony-console-completion 0.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/flex": "^1.1",
         "symfony/dotenv": "^2.8|^3|^4.1",
         "ext-json": "*",
-        "stecman/symfony-console-completion": "^0.8.0",
+        "stecman/symfony-console-completion": "^0.8.0|^0.9.0",
         "symfony/finder": "^4.1",
         "thibaud-dauce/mattermost-php": "^1.2",
         "twig/twig": "^2.5",


### PR DESCRIPTION
Because the major version is "0", the `^0.8.0` constraint does not allow upgrading to 0.9.0.
Compare https://jubianchi.github.io/semver-check/#/^0.8.0/0.9.0 to https://jubianchi.github.io/semver-check/#/^1.8.0/1.9.0. for example.

Not sure if this is a bug in Composer's semantic versioning implementation or if this is expected behavior, but in any case we should allow 0.9.0 to be installed, I think.