### PR TITLE
Add the "phab" binary to composer.json explicitly

### DIFF
--- a/bin/phab
+++ b/bin/phab
@@ -12,7 +12,16 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 set_time_limit(0);
 
-require __DIR__.'/../vendor/autoload.php';
+$autoloaders = [
+  __DIR__ . '/../../../autoload.php',
+  __DIR__ . '/../vendor/autoload.php'
+];
+
+foreach ($autoloaders as $autoloader) {
+  if (file_exists($autoloader)) {
+    require_once $autoloader;
+  }
+}
 
 if (!isset($_SERVER['APP_ENV'])) {
     if (!class_exists(Dotenv::class)) {

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
             "email": "stephan@factorial.io"
         }
     ],
+    "bin": [
+        "bin/phab"
+    ],
     "scripts": {
         "auto-scripts": {
 


### PR DESCRIPTION
This make Composer install the binary to `vendor/bin` if phabalicious is not installed via the phar