### PR TITLE
Feature/integrated multibasebox

### DIFF
--- a/box.json
+++ b/box.json
@@ -5,6 +5,12 @@
     "config/services.yml",
     "vendor/twig/twig/lib/Twig/Test.php"
   ],
+  "directories-bin": [
+    "config/scaffold"
+  ],
+  "blacklist": [
+    "tests/"
+  ],
   "git-tag": "git_tag",
   "output": "build/phabalicious.phar",
   "compression": "GZ"

--- a/config/scaffold/mbb/fabfile.local.yaml
+++ b/config/scaffold/mbb/fabfile.local.yaml
@@ -1,0 +1,18 @@
+{% set remote_host = platform == 'mac' ? 'docker.for.mac.localhost' : '172.17.0.1' %}
+dockerHosts:
+  mbb:
+    runLocally: true
+    rootFolder: {{ rootFolder }}/projects
+{% if platform == 'mac' %}
+    environment:
+      COMPOSE_FILE: "docker-compose.yml:docker-compose-mbb.yml:../../docker-compose-nfs.yml"
+{% endif %}
+
+hosts:
+  mbb:
+    xdebug:
+      remote_host: {{ remote_host }}
+    blueprint:
+      xdebug:
+        remote_host: {{ remote_host }}
+

--- a/config/scaffold/mbb/mbb-base.yml
+++ b/config/scaffold/mbb/mbb-base.yml
@@ -1,0 +1,13 @@
+questions:
+  platform:
+    question: "What platform are you working on (mac|linux)"
+    default: mac
+    validation: (mac|linux)
+    error: "Only `mac` and `linux` are currently supported"
+  branch:
+    question: "What branch should I use to checkout?"
+    default: master
+
+variables:
+  name: MultiBaseBox
+

--- a/config/scaffold/mbb/mbb-update.yml
+++ b/config/scaffold/mbb/mbb-update.yml
@@ -1,25 +1,25 @@
 inheritsFrom:
   - ./mbb-base.yml
 
-questions:
-  name:
-    question: "What folder name would you want to use"
-    default: multibasebox
-
+variables:
+  name: MultiBaseBox
+  allowOverride: true
 
 assets:
   - fabfile.local.yaml
 
 
 scaffold:
-  - log_message(Cloning multibasebox from https://github.com/factorial-io/multibasebox.git ...)
-  - cd %rootFolder%; git clone https://github.com/factorial-io/multibasebox.git --branch %branch% .
+  - log_message(Updating multibasebox from https://github.com/factorial-io/multibasebox.git ...)
+  - cd %rootFolder%; git checkout %branch%; git pull origin
   - copy_assets(%rootFolder%)
   - log_message(The next step might require your admin-password to setup nfs and other things ...)
   - cd %rootFolder%; bash ./setup-docker.sh
 
 successMessage:
   - |
+    Multibasebox successfully updated!
+
     If you are on linux:
     - please configure dnsmasq to resolve .test-domains to 127.0.0.1
     - otherwise add your hosts to /etc/hosts and point them to 127.0.0.1, e.g. multibasebox.test

--- a/config/scaffold/mbb/mbb.yml
+++ b/config/scaffold/mbb/mbb.yml
@@ -1,0 +1,37 @@
+questions:
+  name:
+    question: "What name would you want to use"
+    default: multibasebox
+  platform:
+    question: "What platform are you working on (mac|linux)"
+    default: mac
+    validation: (mac|linux)
+    error: "Only `mac` and `linux` are currently supported"
+
+variables:
+  name: MultiBaseBox
+
+assets:
+  - fabfile.local.yaml
+
+
+scaffold:
+  - log_message(Cloning multibasebox from https://github.com/factorial-io/multibasebox.git ...)
+  - cd %rootFolder%; git clone https://github.com/factorial-io/multibasebox.git .
+  - copy_assets(%rootFolder%)
+  - log_message(The next step might require your admin-password to setup nfs and other things ...)
+  - cd %rootFolder%; bash ./setup-docker.sh
+
+successMessage:
+  - |
+    If you are on linux:
+    - please configure dnsmasq to resolve .test-domains to 127.0.0.1
+    - otherwise add your hosts to /etc/hosts and point them to 127.0.0.1, e.g. multibasebox.test
+
+    Then try visiting http://multibasebox.test:1936 (haproxy/yxorpah), this should give you the admin page of haproxy
+
+    Try visiting http://muitbasebox.test this should give you an 503 error message, which is fine!
+
+    For troubleshooting visit https://github.com/factorial-io/multibasebox
+
+    Happy hacking!

--- a/src/Command/ScaffoldBaseCommand.php
+++ b/src/Command/ScaffoldBaseCommand.php
@@ -1,0 +1,413 @@
+<?php
+
+/** @noinspection PhpRedundantCatchClauseInspection */
+
+namespace Phabalicious\Command;
+
+use Composer\Semver\Comparator;
+use Phabalicious\Configuration\HostConfig;
+use Phabalicious\Exception\MismatchedVersionException;
+use Phabalicious\Exception\ValidationFailedException;
+use Phabalicious\Method\ScriptMethod;
+use Phabalicious\Method\TaskContextInterface;
+use Phabalicious\ShellProvider\CommandResult;
+use Phabalicious\ShellProvider\LocalShellProvider;
+use Phabalicious\Utilities\Utilities;
+use Phabalicious\Validation\ValidationErrorBag;
+use Phabalicious\Validation\ValidationService;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
+
+abstract class ScaffoldBaseCommand extends BaseOptionsCommand
+{
+
+    protected $twig;
+
+    protected $dynamicOptions = [];
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setDefinition(new class($this->getDefinition(), $this->dynamicOptions) extends InputDefinition
+        {
+            protected $dynamicOptions = [];
+
+            public function __construct(InputDefinition $definition, array &$dynamicOptions)
+            {
+                parent::__construct();
+                $this->setArguments($definition->getArguments());
+                $this->setOptions($definition->getOptions());
+                $this->dynamicOptions =& $dynamicOptions;
+            }
+
+            public function getOption($name)
+            {
+                if (!parent::hasOption($name)) {
+                    $this->addOption(new InputOption($name, null, InputOption::VALUE_OPTIONAL));
+                    $this->dynamicOptions[] = $name;
+                }
+                return parent::getOption($name);
+            }
+
+            public function hasOption($name)
+            {
+                return true;
+            }
+
+        });
+    }
+
+    /**
+     * Scaffold sth from an file/url.
+     *
+     * @param $url
+     * @param $root_folder
+     * @param TaskContextInterface $context
+     * @return int
+     * @throws MismatchedVersionException
+     * @throws ValidationFailedException
+     * @throws \Phabalicious\Exception\FabfileNotReadableException
+     * @throws \Phabalicious\Exception\FailedShellCommandException
+     * @throws \Phabalicious\Exception\MissingScriptCallbackImplementation
+     */
+    protected function scaffold($url, $root_folder, TaskContextInterface $context)
+    {
+        $is_remote = false;
+        if (substr($url, 0, 4) !== 'http') {
+            $data = Yaml::parseFile($url);
+            $twig_loader_base = dirname($url);
+        } else {
+            $data = $this->configuration->readHttpResource($url);
+            $data = Yaml::parse($data);
+            $twig_loader_base = '/tmp';
+            $is_remote = true;
+        }
+        if (!$data) {
+            throw new \InvalidArgumentException('Could not read yaml from ' . $url);
+        }
+
+        if ($data && isset($data['requires'])) {
+            $required_version = $data['requires'];
+            $app_version = $this->getApplication()->getVersion();
+            if (Comparator::greaterThan($required_version, $app_version)) {
+                throw new MismatchedVersionException(
+                    sprintf(
+                        'Could not read from %s because of version mismatch. %s is required, current app is %s',
+                        $url,
+                        $required_version,
+                        $app_version
+                    )
+                );
+            }
+        }
+
+        $data['base_path'] = dirname($url);
+
+        if (!empty($data['inheritsFrom'])) {
+            if (!is_array($data['inheritsFrom'])) {
+                $data['inheritsFrom'] = [$data['inheritsFrom']];
+            }
+            if ($is_remote) {
+                foreach ($data['inheritsFrom'] as $item) {
+                    if (substr($item, 0, 4) !== 'http') {
+                        $data['inheritsFrom'] = $data['base_path'] . '/' . $item;
+                    }
+                }
+            }
+        }
+
+        $data = $this->configuration->resolveInheritance($data, [], dirname($url));
+
+        $errors = new ValidationErrorBag();
+        $validation = new ValidationService($data, $errors, 'scaffold');
+
+        $validation->hasKey('scaffold', 'The file needs a scaffold-section.');
+        $validation->hasKey('assets', 'The file needs a scaffold-section.');
+        $validation->hasKey('questions', 'The file needs a questions-section.');
+        if ($errors->hasErrors()) {
+            throw new ValidationFailedException($errors);
+        }
+
+        $tokens = [
+            'uuid' => $this->fakeUUID(),
+        ];
+
+        $questions = !empty($data['questions']) ? $data['questions'] : [];
+
+
+        $tokens = $this->askQuestions($context->getInput(), $questions, $context, $tokens);
+        if (empty($tokens['name'])) {
+            throw new \InvalidArgumentException('Missing `name` in questions, aborting!');
+        }
+        if (!empty($data['variables'])) {
+            $tokens = Utilities::mergeData($data['variables'], $tokens);
+        }
+        if (empty($tokens['projectFolder'])) {
+            $tokens['projectFolder'] = $tokens['name'];
+        }
+
+        // Do a first round of replacements.
+        $replacements = $this->getReplacements($tokens);
+        foreach ($tokens as $ndx => $token) {
+            $tokens[$ndx] = strtr($token, $replacements);
+        }
+
+        $tokens['projectFolder'] = Utilities::cleanupString($tokens['projectFolder']);
+        $tokens['rootFolder'] = realpath($root_folder) . '/' . $tokens['projectFolder'];
+
+        $logger = $this->configuration->getLogger();
+        $shell = new LocalShellProvider($logger);
+        $script = new ScriptMethod($logger);
+
+        $host_config = new HostConfig([
+            'rootFolder' => realpath($context->getInput()->getOption('output')),
+            'shellExecutable' => '/bin/bash'
+        ], $shell, $this->configuration);
+
+        $context->set('scriptData', $data['scaffold']);
+        $context->set('variables', $tokens);
+        $context->set('callbacks', [
+            'copy_assets' => [$this, 'copyAssets'],
+            'log_message' => [$this, 'logMessage']
+        ]);
+        $context->set('scaffoldData', $data);
+        $context->set('tokens', $tokens);
+        $context->set('loaderBase', $twig_loader_base);
+
+        // Setup twig
+        $loader = new \Twig_Loader_Filesystem($twig_loader_base);
+        $this->twig = new \Twig_Environment($loader, array(
+        ));
+
+
+        if (is_dir($tokens['rootFolder'])
+            && empty($context->getInput()->getOption('force'))
+            && empty($context->getInput()->getOption('override'))
+        ) {
+            if (!$context->io()->confirm(
+                'Destination folder exists! Continue anyways?',
+                false
+            )) {
+                return 1;
+            }
+        }
+        if ($context->getOutput()->getVerbosity() == OutputInterface::VERBOSITY_VERBOSE) {
+            $context->io()->note('Available tokens:' . PHP_EOL . print_r($tokens, true));
+        }
+
+        $context->io()->comment('Create destination folder ...');
+        $shell->run(sprintf('mkdir -p %s', $tokens['rootFolder']));
+
+        $context->io()->comment('Start scaffolding script ...');
+        $script->runScript($host_config, $context);
+
+        /** @var CommandResult $result */
+        $result = $context->getResult('commandResult');
+        if ($result && $result->failed()) {
+            throw new \RuntimeException(sprintf(
+                "Scaffolding failed with exit-code %d\n%s",
+                $result->getExitCode(),
+                implode("\n", $result->getOutput())
+            ));
+        }
+
+        $context->io()->success('Scaffolding finished successfully!');
+        if (!empty($data['successMessage'])) {
+            $context->io()->block($data['successMessage'], 'Notes', 'fg=white;bg=blue', ' ', true);
+        }
+        return 0;
+    }
+
+    public function logMessage(TaskContextInterface $context, $log_level, $log_message = '')
+    {
+        if (empty($log_message)) {
+            $log_message = $log_level;
+            $log_level = 'info';
+        }
+        $log_level = strtolower($log_level);
+        if ($log_level == 'success') {
+            $context->io()->success($log_message);
+        } elseif ($log_level == 'warning') {
+            $context->io()->warning($log_message);
+        } elseif ($log_level == 'error') {
+            $context->io()->warning($log_message);
+        } else {
+            $context->io()->note($log_message);
+        }
+    }
+
+    /**
+     * @param TaskContextInterface $context
+     * @param string $target_folder
+     * @param string $data_key
+     * @param bool $limitedForTwigExtension
+     */
+    public function copyAssets(
+        TaskContextInterface $context,
+        $target_folder,
+        $data_key = 'assets',
+        $limitedForTwigExtension = false
+    ) {
+        if (!is_dir($target_folder)) {
+            mkdir($target_folder, 0777, true);
+        }
+        $data = $context->get('scaffoldData');
+        $tokens = $context->get('tokens');
+        $is_remote = substr($data['base_path'], 0, 4) == 'http';
+        $replacements = $this->getReplacements($tokens);
+
+        if (empty($data[$data_key])) {
+            throw new \InvalidArgumentException('Scaffold-data does not contain ' . $data_key);
+        }
+
+        $context->io()->comment(sprintf('Copying assets `%s`', $data_key));
+        $use_progress = count($data[$data_key]) > 3;
+
+        if ($use_progress) {
+            $context->io()->progressStart(count($data[$data_key]));
+        }
+
+        foreach ($data[$data_key] as $file_name) {
+            $tmp_target_file = false;
+            if ($is_remote) {
+                $tmpl = $this->configuration->readHttpResource($data['base_path'] . '/' . $file_name);
+                if ($tmpl === false) {
+                    throw new \RuntimeException('Could not read remote asset: '. $data['base_path'] . '/' . $file_name);
+                }
+                $tmp_target_file = '/tmp/' . $file_name;
+                if (!is_dir(dirname($tmp_target_file))) {
+                    mkdir(dirname($tmp_target_file), 0777, true);
+                }
+                file_put_contents('/tmp/' . $file_name, $tmpl);
+            }
+
+            if ($limitedForTwigExtension &&
+                ('.' . pathinfo($file_name, PATHINFO_EXTENSION) !== $limitedForTwigExtension)
+            ) {
+                $converted = file_get_contents($context->get('loaderBase') . '/' . $file_name);
+            } else {
+                $converted = $this->twig->render($file_name, $tokens);
+            }
+
+            if ($limitedForTwigExtension) {
+                $file_name = str_replace($limitedForTwigExtension, '', $file_name);
+            }
+
+            if ($tmp_target_file) {
+                unlink($tmp_target_file);
+            }
+
+            $file_name = strtr($file_name, $replacements);
+            if (strpos($file_name, '/') !== false) {
+                $file_name = substr($file_name, strpos($file_name, '/', 1) + 1);
+            }
+
+            $target_file_path = $target_folder . '/' . $file_name;
+            if (!is_dir(dirname($target_file_path))) {
+                mkdir(dirname($target_file_path), 0777, true);
+            }
+
+            if ($use_progress) {
+                $context->io()->progressAdvance();
+            }
+            file_put_contents($target_file_path, $converted);
+        }
+        if ($use_progress) {
+            $context->io()->progressFinish();
+        }
+    }
+
+    private function fakeUUID()
+    {
+        return bin2hex(openssl_random_pseudo_bytes(4)) . '-' .
+            bin2hex(openssl_random_pseudo_bytes(2)) . '-' .
+            bin2hex(openssl_random_pseudo_bytes(2)) . '-' .
+            bin2hex(openssl_random_pseudo_bytes(2)) . '-' .
+            bin2hex(openssl_random_pseudo_bytes(6));
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param array $questions
+     * @param TaskContextInterface $context
+     * @param array $tokens
+     * @return array
+     * @throws ValidationFailedException
+     */
+    protected function askQuestions(
+        InputInterface $input,
+        array $questions,
+        TaskContextInterface $context,
+        array $tokens
+    ): array {
+        foreach ($questions as $key => $question_data) {
+            $errors = new ValidationErrorBag();
+            $validation = new ValidationService($question_data, $errors, 'questions');
+            $validation->hasKey('question', 'Please provide a question');
+            if (!empty($question_data['validation'])) {
+                $validation->hasKey('validation', 'Please provide a regex for validation');
+                $validation->hasKey('error', 'Please provide an error message when a validation fails');
+            }
+            if ($errors->hasErrors()) {
+                throw new ValidationFailedException($errors);
+            }
+
+            $option_name = strtolower(preg_replace('%([a-z])([A-Z])%', '\1-\2', $key));
+            if (in_array($option_name, $this->dynamicOptions)) {
+                $value = $input->getOption($option_name);
+            } else {
+                $value = $context->io()->ask(
+                    $question_data['question'],
+                    isset($question_data['default']) ? $question_data['default'] : null
+                );
+            }
+
+            if (!empty($question_data['validation'])) {
+                if (!preg_match($question_data['validation'], $value)) {
+                    throw new \InvalidArgumentException($question_data['error'] . ': ' . $value);
+                }
+            }
+            if (!empty($question_data['transform'])) {
+                $transform = strtolower($question_data['transform']);
+                $mapping = [
+                    'lowercase' => 'strtolower',
+                    'uppercase' => 'strtoupper',
+                ];
+                if (isset($mapping[$transform])) {
+                    $value = call_user_func($mapping[$transform], $value);
+                }
+            }
+            $tokens[$key] = trim($value);
+        }
+        return $tokens;
+    }
+
+    /**
+     * @param array $tokens
+     * @return array
+     */
+    protected function getReplacements($tokens): array
+    {
+        $replacements = [];
+        foreach ($tokens as $key => $value) {
+            $replacements['%' . $key . '%'] = $value;
+        }
+        return $replacements;
+    }
+
+    /**
+     * Get local scaffold file.
+     */
+    protected function getLocalScaffoldFile($name)
+    {
+        $rootFolder = \Phar::running()
+            ? \Phar::running() . '/config/scaffold'
+            : realpath(__DIR__ . '/../../config/scaffold/');
+
+        return $rootFolder . '/' . $name;
+    }
+}

--- a/src/Command/ScaffoldBaseCommand.php
+++ b/src/Command/ScaffoldBaseCommand.php
@@ -5,8 +5,12 @@
 namespace Phabalicious\Command;
 
 use Composer\Semver\Comparator;
+use InvalidArgumentException;
 use Phabalicious\Configuration\HostConfig;
+use Phabalicious\Exception\FabfileNotReadableException;
+use Phabalicious\Exception\FailedShellCommandException;
 use Phabalicious\Exception\MismatchedVersionException;
+use Phabalicious\Exception\MissingScriptCallbackImplementation;
 use Phabalicious\Exception\ValidationFailedException;
 use Phabalicious\Method\ScriptMethod;
 use Phabalicious\Method\TaskContextInterface;
@@ -15,11 +19,15 @@ use Phabalicious\ShellProvider\LocalShellProvider;
 use Phabalicious\Utilities\Utilities;
 use Phabalicious\Validation\ValidationErrorBag;
 use Phabalicious\Validation\ValidationService;
+use Phar;
+use RuntimeException;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
+use Twig_Environment;
+use Twig_Loader_Filesystem;
 
 abstract class ScaffoldBaseCommand extends BaseOptionsCommand
 {
@@ -70,11 +78,11 @@ abstract class ScaffoldBaseCommand extends BaseOptionsCommand
      * @return int
      * @throws MismatchedVersionException
      * @throws ValidationFailedException
-     * @throws \Phabalicious\Exception\FabfileNotReadableException
-     * @throws \Phabalicious\Exception\FailedShellCommandException
-     * @throws \Phabalicious\Exception\MissingScriptCallbackImplementation
+     * @throws FabfileNotReadableException
+     * @throws FailedShellCommandException
+     * @throws MissingScriptCallbackImplementation
      */
-    protected function scaffold($url, $root_folder, TaskContextInterface $context)
+    protected function scaffold($url, $root_folder, TaskContextInterface $context, $tokens = [])
     {
         $is_remote = false;
         if (substr($url, 0, 4) !== 'http') {
@@ -87,7 +95,7 @@ abstract class ScaffoldBaseCommand extends BaseOptionsCommand
             $is_remote = true;
         }
         if (!$data) {
-            throw new \InvalidArgumentException('Could not read yaml from ' . $url);
+            throw new InvalidArgumentException('Could not read yaml from ' . $url);
         }
 
         if ($data && isset($data['requires'])) {
@@ -132,16 +140,15 @@ abstract class ScaffoldBaseCommand extends BaseOptionsCommand
             throw new ValidationFailedException($errors);
         }
 
-        $tokens = [
-            'uuid' => $this->fakeUUID(),
-        ];
+        $tokens['uuid'] = $this->fakeUUID();
+        if (isset($tokens['name'])) {
+            $tokens = Utilities::mergeData($this->readTokens($root_folder, $tokens['name']), $tokens);
+        }
 
         $questions = !empty($data['questions']) ? $data['questions'] : [];
-
-
         $tokens = $this->askQuestions($context->getInput(), $questions, $context, $tokens);
         if (empty($tokens['name'])) {
-            throw new \InvalidArgumentException('Missing `name` in questions, aborting!');
+            throw new InvalidArgumentException('Missing `name` in questions, aborting!');
         }
         if (!empty($data['variables'])) {
             $tokens = Utilities::mergeData($data['variables'], $tokens);
@@ -179,14 +186,15 @@ abstract class ScaffoldBaseCommand extends BaseOptionsCommand
         $context->set('loaderBase', $twig_loader_base);
 
         // Setup twig
-        $loader = new \Twig_Loader_Filesystem($twig_loader_base);
-        $this->twig = new \Twig_Environment($loader, array(
+        $loader = new Twig_Loader_Filesystem($twig_loader_base);
+        $this->twig = new Twig_Environment($loader, array(
         ));
 
 
         if (is_dir($tokens['rootFolder'])
             && empty($context->getInput()->getOption('force'))
             && empty($context->getInput()->getOption('override'))
+            && empty($tokens['allowOverride'])
         ) {
             if (!$context->io()->confirm(
                 'Destination folder exists! Continue anyways?',
@@ -208,17 +216,19 @@ abstract class ScaffoldBaseCommand extends BaseOptionsCommand
         /** @var CommandResult $result */
         $result = $context->getResult('commandResult');
         if ($result && $result->failed()) {
-            throw new \RuntimeException(sprintf(
+            throw new RuntimeException(sprintf(
                 "Scaffolding failed with exit-code %d\n%s",
                 $result->getExitCode(),
                 implode("\n", $result->getOutput())
             ));
         }
 
-        $context->io()->success('Scaffolding finished successfully!');
         if (!empty($data['successMessage'])) {
             $context->io()->block($data['successMessage'], 'Notes', 'fg=white;bg=blue', ' ', true);
         }
+        $this->writeTokens($tokens['rootFolder'], $tokens);
+
+        $context->io()->success('Scaffolding finished successfully!');
         return 0;
     }
 
@@ -261,7 +271,7 @@ abstract class ScaffoldBaseCommand extends BaseOptionsCommand
         $replacements = $this->getReplacements($tokens);
 
         if (empty($data[$data_key])) {
-            throw new \InvalidArgumentException('Scaffold-data does not contain ' . $data_key);
+            throw new InvalidArgumentException('Scaffold-data does not contain ' . $data_key);
         }
 
         $context->io()->comment(sprintf('Copying assets `%s`', $data_key));
@@ -276,7 +286,7 @@ abstract class ScaffoldBaseCommand extends BaseOptionsCommand
             if ($is_remote) {
                 $tmpl = $this->configuration->readHttpResource($data['base_path'] . '/' . $file_name);
                 if ($tmpl === false) {
-                    throw new \RuntimeException('Could not read remote asset: '. $data['base_path'] . '/' . $file_name);
+                    throw new RuntimeException('Could not read remote asset: '. $data['base_path'] . '/' . $file_name);
                 }
                 $tmp_target_file = '/tmp/' . $file_name;
                 if (!is_dir(dirname($tmp_target_file))) {
@@ -357,7 +367,9 @@ abstract class ScaffoldBaseCommand extends BaseOptionsCommand
             }
 
             $option_name = strtolower(preg_replace('%([a-z])([A-Z])%', '\1-\2', $key));
-            if (in_array($option_name, $this->dynamicOptions)) {
+            if (isset($tokens[$key])) {
+                $value = $tokens[$key];
+            } elseif (in_array($option_name, $this->dynamicOptions)) {
                 $value = $input->getOption($option_name);
             } else {
                 $value = $context->io()->ask(
@@ -368,7 +380,7 @@ abstract class ScaffoldBaseCommand extends BaseOptionsCommand
 
             if (!empty($question_data['validation'])) {
                 if (!preg_match($question_data['validation'], $value)) {
-                    throw new \InvalidArgumentException($question_data['error'] . ': ' . $value);
+                    throw new InvalidArgumentException($question_data['error'] . ': ' . $value);
                 }
             }
             if (!empty($question_data['transform'])) {
@@ -404,10 +416,25 @@ abstract class ScaffoldBaseCommand extends BaseOptionsCommand
      */
     protected function getLocalScaffoldFile($name)
     {
-        $rootFolder = \Phar::running()
-            ? \Phar::running() . '/config/scaffold'
+        $rootFolder = Phar::running()
+            ? Phar::running() . '/config/scaffold'
             : realpath(__DIR__ . '/../../config/scaffold/');
 
         return $rootFolder . '/' . $name;
+    }
+    
+    protected function writeTokens($root_folder, $tokens)
+    {
+        file_put_contents($root_folder . '/.phab-scaffold-tokens', YAML::dump($tokens));
+    }
+
+    protected function readTokens($root_folder, $name)
+    {
+        $full_path = "$root_folder/$name/.phab-scaffold-tokens";
+        if (!file_exists($full_path)) {
+            return [];
+        }
+        $tokens = yaml::parseFile($full_path);
+        return is_array($tokens) ? $tokens : [];
     }
 }

--- a/src/Command/WorkspaceCreateCommand.php
+++ b/src/Command/WorkspaceCreateCommand.php
@@ -52,7 +52,6 @@ class WorkspaceCreateCommand extends ScaffoldBaseCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $url  = $this->getLocalScaffoldFile('mbb/mbb.yml');
-        $output->writeln($url);
         $root_folder = empty($input->getOption('output')) ? getcwd() : $input->getOption('output');
         $context = new TaskContext($this, $input, $output);
 

--- a/src/Command/WorkspaceCreateCommand.php
+++ b/src/Command/WorkspaceCreateCommand.php
@@ -12,8 +12,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class WorkspaceCreateCommand extends ScaffoldBaseCommand
 {
 
-    protected $twig;
-
     protected function configure()
     {
         parent::configure();

--- a/src/Command/WorkspaceCreateCommand.php
+++ b/src/Command/WorkspaceCreateCommand.php
@@ -5,27 +5,22 @@ namespace Phabalicious\Command;
 use Phabalicious\Exception\MismatchedVersionException;
 use Phabalicious\Exception\ValidationFailedException;
 use Phabalicious\Method\TaskContext;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class AppScaffoldCommand extends ScaffoldBaseCommand
+class WorkspaceCreateCommand extends ScaffoldBaseCommand
 {
+
+    protected $twig;
+
     protected function configure()
     {
         parent::configure();
         $this
-            ->setName('app:scaffold')
-            ->setDescription('Scaffolds an app from a remote scaffold-instruction')
-            ->setHelp('Scaffolds an app from a remote scaffold-instruction');
-
-        $this->addArgument(
-            'scaffold-url',
-            InputArgument::REQUIRED,
-            'the url/path to load the scaffold-yaml from'
-        );
-
+            ->setName('workspace:create')
+            ->setDescription('Creates a multibasebox workspace')
+            ->setHelp('Scaffolds a multibasebox workspace on your local.');
 
         $this->addOption(
             'output',
@@ -56,7 +51,8 @@ class AppScaffoldCommand extends ScaffoldBaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $url = $input->getArgument('scaffold-url');
+        $url  = $this->getLocalScaffoldFile('mbb/mbb.yml');
+        $output->writeln($url);
         $root_folder = empty($input->getOption('output')) ? getcwd() : $input->getOption('output');
         $context = new TaskContext($this, $input, $output);
 

--- a/src/Command/WorkspaceUpdateCommand.php
+++ b/src/Command/WorkspaceUpdateCommand.php
@@ -9,13 +9,10 @@ use Phabalicious\Exception\MissingScriptCallbackImplementation;
 use Phabalicious\Exception\ValidationFailedException;
 use Phabalicious\Method\TaskContext;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class WorkspaceUpdateCommand extends ScaffoldBaseCommand
 {
-
-    protected $twig;
 
     protected function configure()
     {

--- a/src/Command/WorkspaceUpdateCommand.php
+++ b/src/Command/WorkspaceUpdateCommand.php
@@ -8,42 +8,22 @@ use Phabalicious\Exception\MismatchedVersionException;
 use Phabalicious\Exception\MissingScriptCallbackImplementation;
 use Phabalicious\Exception\ValidationFailedException;
 use Phabalicious\Method\TaskContext;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class AppScaffoldCommand extends ScaffoldBaseCommand
+class WorkspaceUpdateCommand extends ScaffoldBaseCommand
 {
+
+    protected $twig;
+
     protected function configure()
     {
         parent::configure();
         $this
-            ->setName('app:scaffold')
-            ->setDescription('Scaffolds an app from a remote scaffold-instruction')
-            ->setHelp('Scaffolds an app from a remote scaffold-instruction');
-
-        $this->addArgument(
-            'scaffold-url',
-            InputArgument::REQUIRED,
-            'the url/path to load the scaffold-yaml from'
-        );
-
-
-        $this->addOption(
-            'output',
-            null,
-            InputOption::VALUE_OPTIONAL,
-            'the folder where to create the new project',
-            false
-        );
-        $this->addOption(
-            'override',
-            null,
-            InputOption::VALUE_OPTIONAL,
-            'Set to true if you want to override existing folders',
-            false
-        );
+            ->setName('workspace:update')
+            ->setDescription('Updates a multibasebox workspace')
+            ->setHelp('Updates a multibasebox workspace on your local.');
     }
 
     /**
@@ -59,11 +39,29 @@ class AppScaffoldCommand extends ScaffoldBaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $url = $input->getArgument('scaffold-url');
-        $root_folder = empty($input->getOption('output')) ? getcwd() : $input->getOption('output');
+        $url  = $this->getLocalScaffoldFile('mbb/mbb-update.yml');
+        $root_folder = $this->findRootFolder(getcwd());
+        if (!$root_folder) {
+            throw new \InvalidArgumentException('Could not find multibasebox root folder!');
+        }
         $context = new TaskContext($this, $input, $output);
 
-        $this->scaffold($url, $root_folder, $context);
+        $name = basename($root_folder);
+        $root_folder = dirname($root_folder);
+        $this->scaffold($url, $root_folder, $context, ['name' => $name]);
         return 0;
+    }
+    
+    private function findRootFolder($start_folder, $max_level = 10)
+    {
+        if (file_exists($start_folder . '/setup-docker.sh')) {
+            return $start_folder;
+        }
+        $max_level--;
+        $start_folder = dirname($start_folder);
+        if ($max_level == 0 || $start_folder == DIRECTORY_SEPARATOR) {
+            return false;
+        }
+        return $this->findRootFolder($start_folder, $max_level - 1);
     }
 }


### PR DESCRIPTION
Hi Shibin,

(I know you are still on holidays, feel free to decline the review) 

Here are some code changes to introduce two new commands:
  * `workspace:create`
  * `workspace:update`

Both commands will try to streamline the process to setup and update a local multibasebox installation. Both commands use local scaffold files (packaged into the phar), so we can introduce changes with new versions of phabalicious. The github repository for multibasebox is still used as a base. 

The PR includes other changes, all tokens acquired via questions or command line options will be saved as yaml in the project-folder, (in a file called `.phab-scaffold-tokens.yml`) so additional invocations of a scaffold command can pick up the saved tokens and reuse them. That will enhance the DX when something fails, as you do only need to provide a name like `phab app:scaffold foo --name bar` 

After a successful review I'll add some documentation and most importantly change the documentation on https://github.com/factorial-io/multibasebox, so it refers to phabalicious on how to install multibasebox. 

In the end, multibasebox will be a feature of phabalicious.