### PR TITLE
Feature/push and pull variables

### DIFF
--- a/src/Command/VariablePull.php
+++ b/src/Command/VariablePull.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Phabalicious\Command;
+
+use Phabalicious\Exception\BlueprintTemplateNotFoundException;
+use Phabalicious\Exception\FabfileNotFoundException;
+use Phabalicious\Exception\FabfileNotReadableException;
+use Phabalicious\Exception\MethodNotFoundException;
+use Phabalicious\Exception\MismatchedVersionException;
+use Phabalicious\Exception\MissingDockerHostConfigException;
+use Phabalicious\Exception\ShellProviderNotFoundException;
+use Phabalicious\Exception\TaskNotFoundInMethodException;
+use Phabalicious\Method\TaskContext;
+use Phabalicious\Utilities\Utilities;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
+
+class VariablePull extends BaseCommand
+{
+
+    protected function configure()
+    {
+        parent::configure();
+        $this
+            ->setName('variable:pull')
+            ->setDescription('Pulls a list of variables from a host ' .
+                'and updates the given yaml file, or create it if it does not exist.')
+            ->setHelp('Pulls a list of variables from a host ' .
+                'and updates the given yaml file, or create it if it does not exist.');
+        $this->addArgument('file', InputArgument::REQUIRED, 'yaml file to update, will be created if not existing');
+        $this->addOption('output', 'o', InputOption::VALUE_OPTIONAL);
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null
+     * @throws BlueprintTemplateNotFoundException
+     * @throws FabfileNotFoundException
+     * @throws FabfileNotReadableException
+     * @throws MethodNotFoundException
+     * @throws MismatchedVersionException
+     * @throws MissingDockerHostConfigException
+     * @throws ShellProviderNotFoundException
+     * @throws TaskNotFoundInMethodException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($result = parent::execute($input, $output)) {
+            return $result;
+        }
+
+        $context = new TaskContext($this, $input, $output);
+
+        $context->set('action', 'pull');
+        $filename = $input->getArgument('file');
+        $data = Yaml::parseFile($filename);
+        $context->set('data', $data);
+        $this->getMethods()->runTask('variables', $this->getHostConfig(), $context);
+
+        $data = Utilities::mergeData($data, $context->getResult('data', []));
+        if ($input->getOption('output')) {
+            $filename = $input->getOption('output');
+        }
+        if (file_put_contents($filename, Yaml::dump($data, 4, 2))) {
+            $context->io()->success('Variables written to '. $filename);
+            return 0;
+        }
+
+        $context->io()->error('Could not write to '.$filename);
+        return 1;
+    }
+}

--- a/src/Command/VariablePull.php
+++ b/src/Command/VariablePull.php
@@ -53,7 +53,7 @@ class VariablePull extends BaseCommand
             return $result;
         }
 
-        $context = new TaskContext($this, $input, $output);
+        $context = $this->createContext($input, $output);
 
         $context->set('action', 'pull');
         $filename = $input->getArgument('file');

--- a/src/Command/VariablePush.php
+++ b/src/Command/VariablePush.php
@@ -50,7 +50,7 @@ class VariablePush extends BaseCommand
             return $result;
         }
 
-        $context = new TaskContext($this, $input, $output);
+        $context = $this->createContext($input, $output);
 
         $context->set('action', 'push');
         $filename = $input->getArgument('file');

--- a/src/Command/VariablePush.php
+++ b/src/Command/VariablePush.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Phabalicious\Command;
+
+use Phabalicious\Exception\BlueprintTemplateNotFoundException;
+use Phabalicious\Exception\FabfileNotFoundException;
+use Phabalicious\Exception\FabfileNotReadableException;
+use Phabalicious\Exception\MethodNotFoundException;
+use Phabalicious\Exception\MismatchedVersionException;
+use Phabalicious\Exception\MissingDockerHostConfigException;
+use Phabalicious\Exception\ShellProviderNotFoundException;
+use Phabalicious\Exception\TaskNotFoundInMethodException;
+use Phabalicious\Method\TaskContext;
+use Phabalicious\Utilities\Utilities;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
+
+class VariablePush extends BaseCommand
+{
+
+    protected function configure()
+    {
+        parent::configure();
+        $this
+            ->setName('variable:push')
+            ->setDescription('Pushes a list of variables to a host.')
+            ->setHelp('Pushes a list of variables to a host.');
+        $this->addArgument('file', InputArgument::REQUIRED, 'yaml file to update, will be created if not existing');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null
+     * @throws BlueprintTemplateNotFoundException
+     * @throws FabfileNotFoundException
+     * @throws FabfileNotReadableException
+     * @throws MethodNotFoundException
+     * @throws MismatchedVersionException
+     * @throws MissingDockerHostConfigException
+     * @throws ShellProviderNotFoundException
+     * @throws TaskNotFoundInMethodException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($result = parent::execute($input, $output)) {
+            return $result;
+        }
+
+        $context = new TaskContext($this, $input, $output);
+
+        $context->set('action', 'push');
+        $filename = $input->getArgument('file');
+        $data = Yaml::parseFile($filename);
+        $context->set('data', $data);
+        $this->getMethods()->runTask('variables', $this->getHostConfig(), $context);
+
+        return 0;
+    }
+}

--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -688,6 +688,8 @@ class DrushMethod extends BaseMethod implements MethodInterface
         $result = $context->get('data', []);
         $what = $context->get('action', 'pull');
 
+        $context->io()->progressStart(count($result));
+
         foreach ($result as $key => $value) {
             if ($what == 'pull') {
                 $this->logger->info(sprintf('Pulling `%s` from `%s`', $key, $host_config['configName']));
@@ -696,7 +698,9 @@ class DrushMethod extends BaseMethod implements MethodInterface
                 $this->logger->info(sprintf('Pushing `%s` to `%s`', $key, $host_config['configName']));
                 $this->putVariable($host_config, $context, $key, $value);
             }
+            $context->io()->progressAdvance();
         }
+        $context->io()->progressFinish();
         $context->setResult('data', $result);
     }
 
@@ -714,7 +718,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
             return isset($json[$key]) ? $json[$key] : null;
         }
 
-        return null;
+        throw new \InvalidArgumentException('getVariable is not implemented for that particular drupal version.');
     }
 
     private function putVariable(HostConfig $host_config, TaskContextInterface $context, $key, $value)
@@ -726,10 +730,12 @@ class DrushMethod extends BaseMethod implements MethodInterface
                 '#!drush variable-set --yes --format=json %s \'%s\'',
                 $key,
                 json_encode($value)
-            ), false);
+            ), true);
             if ($output->failed()) {
                 throw new \RuntimeException($output->getOutput());
             }
+            return;
         }
+        throw new \InvalidArgumentException('putVariable is not implemented for that particular drupal version.');
     }
 }

--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -682,4 +682,54 @@ class DrushMethod extends BaseMethod implements MethodInterface
 
         $shell->cd($cwd);
     }
+
+    public function variables(HostConfig $host_config, TaskContextInterface $context)
+    {
+        $result = $context->get('data', []);
+        $what = $context->get('action', 'pull');
+
+        foreach ($result as $key => $value) {
+            if ($what == 'pull') {
+                $this->logger->info(sprintf('Pulling `%s` from `%s`', $key, $host_config['configName']));
+                $result[$key] = $this->getVariable($host_config, $context, $key);
+            } elseif ($what == 'push' && !is_null($value)) {
+                $this->logger->info(sprintf('Pushing `%s` to `%s`', $key, $host_config['configName']));
+                $this->putVariable($host_config, $context, $key, $value);
+            }
+        }
+        $context->setResult('data', $result);
+    }
+
+    private function getVariable(HostConfig $host_config, TaskContextInterface $context, $key)
+    {
+        /** @var ShellProviderInterface $shell */
+        $shell = $context->get('shell', $host_config->shell());
+        if ($host_config['drupalVersion'] == 7) {
+            $output = $shell->run(sprintf('#!drush variable-get --format=json %s', $key), true);
+            if ($output->failed()) {
+                $this->logger->error(implode("\n", $output->getOutput()));
+                return null;
+            }
+            $json = json_decode(implode("\n", $output->getOutput()), true);
+            return isset($json[$key]) ? $json[$key] : null;
+        }
+
+        return null;
+    }
+
+    private function putVariable(HostConfig $host_config, TaskContextInterface $context, $key, $value)
+    {
+        /** @var ShellProviderInterface $shell */
+        $shell = $context->get('shell', $host_config->shell());
+        if ($host_config['drupalVersion'] == 7) {
+            $output = $shell->run(sprintf(
+                '#!drush variable-set --yes --format=json %s \'%s\'',
+                $key,
+                json_encode($value)
+            ), false);
+            if ($output->failed()) {
+                throw new \RuntimeException($output->getOutput());
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR will add two new commands, `variable:pull` and `variable:push`. Both commands require a yaml file wher the first-level keys are used for getting or setting the variables.

D8 implementation is missing.

You can test it by creating a file like this:
```
bi_hub_component_external_url: false
bi_hub_component_hubconfig_external: false
bi_hub_component_hubconfig_internal: false
bi_hub_component_hubcore_url: false

```

and then by running 
```
phab -cconfig variable:pull thefilename
```

and 
```
phab -cconfig variable:push thefilename
``` 