### PR TITLE
Feature/remove entity updates option in drush reset

### DIFF
--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -207,7 +207,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
         // Database updates
         if ($host_config['drupalVersion'] >= 8) {
             $this->runDrush($shell, 'cr -y');
-            $this->runDrush($shell, 'updb --entity-updates -y');
+            $this->runDrush($shell, 'updb -y');
         } else {
             $this->runDrush($shell, 'updb -y ');
         }


### PR DESCRIPTION
> Support for automatic entity updates has been removed in Drupal 8.7.x
> https://www.drupal.org/node/3034742
> 

Also I find a particular use case where it is not desirable and follow/ensure that these fields are removed properly via hook_update_N.

Here is a PR removing the option from drupal reset. Worst case, for users who still want to do entity-updates, can do that explicitely in resetFinished or something.
