### PR TITLE
Fix kubernetes put-file and get-file tasks.

### DIFF
--- a/src/ShellProvider/KubectlShellProvider.php
+++ b/src/ShellProvider/KubectlShellProvider.php
@@ -142,7 +142,7 @@ class KubectlShellProvider extends LocalShellProvider implements ShellProviderIn
         $command = $this->getKubeCmd();
         $command[] = 'cp';
         $command[] = trim($source);
-        $command[] = $this->hostConfig['kube']['podForCli'] . ':' . trim($dest);
+        $command[] = $this->hostConfig['kube']['podForCli'] . ':' . trim($dest) . '/' . basename($source);
 
         return $command;
     }

--- a/src/ShellProvider/KubectlShellProvider.php
+++ b/src/ShellProvider/KubectlShellProvider.php
@@ -157,7 +157,7 @@ class KubectlShellProvider extends LocalShellProvider implements ShellProviderIn
         $command = $this->getKubeCmd();
         $command[] = 'cp';
         $command[] = $this->hostConfig['kube']['podForCli'] . ':' . trim($source);
-        $command[] = trim($dest);
+        $command[] = trim($dest) . '/' . basename($source);
 
         return $command;
     }


### PR DESCRIPTION
Without this `get:sql-dump` command fails with `error: open /path/to/my/project/root: is a directory`.