### PR TITLE
Existing config install

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -406,4 +406,10 @@ abstract class BaseCommand extends BaseOptionsCommand
         }, $input_arguments);
         return implode(' ', $arguments);
     }
+
+    protected function hasForceOption(InputInterface $input): bool
+    {
+        $option = $input->getOption('force');
+         return is_null($option) || !empty($option);
+    }
 }

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -2,12 +2,18 @@
 
 namespace Phabalicious\Command;
 
+use Phabalicious\Exception\BlueprintTemplateNotFoundException;
 use Phabalicious\Exception\EarlyTaskExitException;
-use Phabalicious\Method\TaskContext;
+use Phabalicious\Exception\FabfileNotFoundException;
+use Phabalicious\Exception\FabfileNotReadableException;
+use Phabalicious\Exception\MethodNotFoundException;
+use Phabalicious\Exception\MismatchedVersionException;
+use Phabalicious\Exception\MissingDockerHostConfigException;
+use Phabalicious\Exception\ShellProviderNotFoundException;
+use Phabalicious\Exception\TaskNotFoundInMethodException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class InstallCommand extends BaseCommand
 {
@@ -32,14 +38,14 @@ class InstallCommand extends BaseCommand
      * @param OutputInterface $output
      *
      * @return int|null
-     * @throws \Phabalicious\Exception\BlueprintTemplateNotFoundException
-     * @throws \Phabalicious\Exception\FabfileNotFoundException
-     * @throws \Phabalicious\Exception\FabfileNotReadableException
-     * @throws \Phabalicious\Exception\MethodNotFoundException
-     * @throws \Phabalicious\Exception\MismatchedVersionException
-     * @throws \Phabalicious\Exception\MissingDockerHostConfigException
-     * @throws \Phabalicious\Exception\ShellProviderNotFoundException
-     * @throws \Phabalicious\Exception\TaskNotFoundInMethodException
+     * @throws BlueprintTemplateNotFoundException
+     * @throws FabfileNotFoundException
+     * @throws FabfileNotReadableException
+     * @throws MethodNotFoundException
+     * @throws MismatchedVersionException
+     * @throws MissingDockerHostConfigException
+     * @throws ShellProviderNotFoundException
+     * @throws TaskNotFoundInMethodException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -54,7 +60,7 @@ class InstallCommand extends BaseCommand
             throw new \InvalidArgumentException('This configuration disallows installs!');
         }
 
-        if (!$input->getOption('force') !== false) {
+        if (!$this->hasForceOption($input)) {
             if (!$context->io()->confirm(sprintf(
                 'Install new database for configuration `%s`?',
                 $this->getHostConfig()['configName']

--- a/src/Configuration/ConfigurationService.php
+++ b/src/Configuration/ConfigurationService.php
@@ -246,7 +246,7 @@ class ConfigurationService
         $data = Yaml::parseFile($file);
         $ext = '.' . pathinfo($file, PATHINFO_EXTENSION);
         $override_file = str_replace($ext, '.override' . $ext, $file);
-        $this->logger->info(sprintf('Trying to read data from override `%s`', $override_file));
+        $this->logger->debug(sprintf('Trying to read data from override `%s`', $override_file));
 
         if (file_exists($override_file)) {
             $data = Utilities::mergeData($data, Yaml::parseFile($override_file));

--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -88,7 +88,12 @@ class DrushMethod extends BaseMethod implements MethodInterface
     {
         $config = parent::getDefaultConfig($configuration_service, $host_config);
 
-        $keys = ['adminUser', 'revertFeatures', 'replaceSettingsFile', 'configurationManagement', 'installOptions'];
+        $keys = ['adminUser',
+            'revertFeatures',
+            'alterSettingsFile',
+            'replaceSettingsFile',
+            'configurationManagement',
+            'installOptions'];
         foreach ($keys as $key) {
             $config[$key] = $configuration_service->getSetting($key);
         }
@@ -722,7 +727,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
     private function setupConfigurationManagement(HostConfig $host_config, TaskContextInterface $context)
     {
         if ($host_config['drupalVersion'] < 8
-            || !empty($host_config['alterSettingsFile'])
+            || empty($host_config['alterSettingsFile'])
             || $context->getResult(self::CONFIGURATION_USED, false)
         ) {
             return;

--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -825,7 +825,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
 
         if ($settings_file_exists) {
             $result = $shell->run(
-                '#!grep -q "^\$settings\[\'config_sync_directory\'] = \'../config/\'" settings.php',
+                '#!grep -q "^\$settings\[\'config_sync_directory\'] = \'../config/" settings.php',
                 true,
                 false
             );


### PR DESCRIPTION
Based on the work of @mikran I refactored the code even more to support more use cases:

Supports now installation from configuration if the setttings.php is correct. phab will try to detect if CIM is setup correctly. Fresh
installs (e.g. from newly scaffolded projects, see #45 ) should also install without errors. Smaller changes to mysql-db-creation as mysql does not support setting the pw for existing users. Better error reporting and hopefully cleaner code.

Can you review the code and do some tests? 