### PR TITLE
Add support for `deploy`-command from drush 10.3

### DIFF
--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -230,6 +230,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
         // Database updates
         if ($host_config['drupalVersion'] >= 8) {
             $this->runDrush($shell, 'updb -y --no-cache-clear');
+            $this->runDrush($shell, 'cr -y');
         } else {
             $this->runDrush($shell, 'updb -y ');
         }

--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -274,7 +274,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
         } else {
             $this->runDrush($shell, 'cc all -y');
         }
-        if ($host_config['drushVersion'] >=10) {
+        if ($host_config['drushVersion'] >= 10) {
             $this->runDrush($shell, 'deploy:hook');
         }
     }

--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -229,8 +229,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
 
         // Database updates
         if ($host_config['drupalVersion'] >= 8) {
-            $this->runDrush($shell, 'cr -y');
-            $this->runDrush($shell, 'updb -y');
+            $this->runDrush($shell, 'updb -y --no-cache-clear');
         } else {
             $this->runDrush($shell, 'updb -y ');
         }

--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -274,6 +274,9 @@ class DrushMethod extends BaseMethod implements MethodInterface
         } else {
             $this->runDrush($shell, 'cc all -y');
         }
+        if ($host_config['drushVersion'] >=10) {
+            $this->runDrush($shell, 'deploy:hook');
+        }
     }
 
     public function drush(HostConfig $host_config, TaskContextInterface $context)


### PR DESCRIPTION
This small change will add support for drush's `deploy`-command and its hook-system.

 Closing #106