### PR TITLE
Add new callback `scaffold` which allows running additional scaffolds…

### DIFF
--- a/docs/scaffolder.md
+++ b/docs/scaffolder.md
@@ -185,6 +185,22 @@ scaffold:
   - confirm(<message>)
 ```
 
+## `scaffold(url, rootFolder)`
+
+This internal command will run another scaffolder from the given `url` or filepath into the given `rootFolder`.
+
+```yaml
+questions: []
+assets: []
+variables:
+themeFolder: "%rootFolder%/web/themes/custom/some_frontend"
+
+scaffold:
+    - scaffold("http://foo.bar/d8.yml", "%rootFolder%")
+    - scaffold("http://foo.bar/d8-theme.yml", "%themeFolder%")
+    - scaffold("http://foo.bar/d8-module.yml", "%rootFolder%/web/modules/custom/d8-module")
+```
+
 ## `transform`
 
 This internal command will transform a list of yml files to sth different with the help of plugins. THe plugins need to be declared in the `plugins`-section.

--- a/docs/scaffolder.md
+++ b/docs/scaffolder.md
@@ -187,7 +187,7 @@ scaffold:
 
 ## `scaffold(url, rootFolder)`
 
-This internal command will run another scaffolder from the given `url` or filepath into the given `rootFolder`.
+This internal command will run another scaffolder from the given `url` or filepath into the given `rootFolder`. Additional arguments in the form of `key=value` will be passed to the scaffolder.
 
 ```yaml
 questions: []
@@ -198,7 +198,7 @@ themeFolder: "%rootFolder%/web/themes/custom/some_frontend"
 scaffold:
     - scaffold("http://foo.bar/d8.yml", "%rootFolder%")
     - scaffold("http://foo.bar/d8-theme.yml", "%themeFolder%")
-    - scaffold("http://foo.bar/d8-module.yml", "%rootFolder%/web/modules/custom/d8-module")
+    - scaffold("http://foo.bar/d8-module.yml", "%rootFolder%/web/modules/custom/d8-module", "key1=value1", "key2=value2")
 ```
 
 ## `transform`

--- a/docs/scaffolder.md
+++ b/docs/scaffolder.md
@@ -14,6 +14,9 @@ Phabalicious supports not only scaffolding new applications, but arbitrary files
 phab scaffold path/to/scaffold-file.yaml
 ```
 
+If you want to preview the command, add the `--dry-run`-option, this will output all commands to the console instead of executing them.
+
+
 ## the scaffold-file
 
 The scaffold-file has the same structure as used for scaffolding applications. Here's an example:
@@ -107,7 +110,7 @@ dataToInject:
     two: far
 
 scaffold:
-  alter_json_file(config.yaml, dataToInject)
+  alter_yaml_file(config.yaml, dataToInject)
 ```
 ## `assert_zero(variable, error_message)`
 

--- a/docs/scaffolder.md
+++ b/docs/scaffolder.md
@@ -45,7 +45,12 @@ scaffold:
 * `log_message` to print a message with a severity
 * `copy_assets` to copy assets and apply replacement patterns
 * `alter_json_file` which will alter an existing json file and change some data
+* `alter_yaml_file` which will alter an existing yaml file and change some data
 * `assert_file` throws an exception if the file does not exist
+* `assert_zero` will stop the execution if the argument is not zero
+* `assert_non_zero` will stop the execution if the argument is zero
+* `assert_contains` will stop the execution if the argument does nt contain given string
+* `set_directory` sets the working directory  to the argument
 
 ### List of commands which needs one or more plugin implementations
 
@@ -88,6 +93,53 @@ scaffold:
   alter_json_file(package.json, dataToInject)
 ```
 
+## `alter_yaml_file(file_path, data_ref)`
+
+This internal command can alter a yaml-file. It will merge the data from a yaml section into the yaml file. Note that the order in the resulting yaml file might be different, also comments might get removed. Here's an example:
+
+```yaml
+
+dataToInject:
+  one: foo
+  two: bar
+  dict:
+    one: boo
+    two: far
+
+scaffold:
+  alter_json_file(config.yaml, dataToInject)
+```
+## `assert_zero(variable, error_message)`
+
+This internal command will throw an exception if the specified argument is not zero.
+
+```yaml
+variables:
+    foo: 1
+scaffold:
+  - assert_zero(%foo%, foo is not zero)
+```
+
+## `assert_non_zero(variable, error_message)`
+
+This internal command will throw an exception if the specified argument is zero.
+
+```yaml
+variables:
+    foo: 0
+scaffold:
+  - assert_non_zero(%foo%, foo is zero)
+```
+
+## `assert_contains(needle, haystack)`
+
+This internal command will throw an exception if `needle` is not found in `haystack`
+
+```yaml
+scaffold:
+  - assert_contains(foo, bar, Could not find foo)
+-
+```
 ## `assert_file(file_path, error_message)`
 
 This internal command will throw an exception if the specified file does not exist. Useful to check if the user is in the right directory.
@@ -95,6 +147,33 @@ This internal command will throw an exception if the specified file does not exi
 ```yaml
 scaffold:
   - assert_file(<file_path>, <error_message>)
+```
+## `assert_file(file_path, error_message)`
+
+This internal command will throw an exception if the specified file does not exist. Useful to check if the user is in the right directory.
+
+```yaml
+scaffold:
+  - assert_file(<file_path>, <error_message>)
+```
+
+## `assert_file(file_path, error_message)`
+
+This internal command will throw an exception if the specified file does not exist. Useful to check if the user is in the right directory.
+
+```yaml
+scaffold:
+  - assert_file(<file_path>, <error_message>)
+```
+
+## `set_directory(directory)`
+
+This internal command will change the current directory for the following commands to `directory`.
+
+```yaml
+scaffold:
+  - set_directory(<directory>)
+  - echo $PWD # will output <directory>
 ```
 
 ## `confirm(message)`

--- a/src/Command/AppCreateCommand.php
+++ b/src/Command/AppCreateCommand.php
@@ -3,7 +3,6 @@
 namespace Phabalicious\Command;
 
 use Phabalicious\Exception\BlueprintTemplateNotFoundException;
-use Phabalicious\Exception\EarlyTaskExitException;
 use Phabalicious\Exception\FabfileNotFoundException;
 use Phabalicious\Exception\FabfileNotReadableException;
 use Phabalicious\Exception\MethodNotFoundException;
@@ -13,10 +12,8 @@ use Phabalicious\Exception\MissingHostConfigException;
 use Phabalicious\Exception\ShellProviderNotFoundException;
 use Phabalicious\Exception\TaskNotFoundInMethodException;
 use Phabalicious\Exception\ValidationFailedException;
-use Phabalicious\Method\TaskContext;
 use Phabalicious\ShellProvider\ShellProviderInterface;
 use Phabalicious\Utilities\AppDefaultStages;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -416,6 +416,6 @@ abstract class BaseCommand extends BaseOptionsCommand
 
     protected function hasForceOption(InputInterface $input): bool
     {
-         return Utilities::hasForceOption($input);
+         return Utilities::hasBoolOptionSet($input, 'force');
     }
 }

--- a/src/Command/ScaffoldCommand.php
+++ b/src/Command/ScaffoldCommand.php
@@ -11,8 +11,10 @@ use Phabalicious\Method\TaskContext;
 use Phabalicious\Scaffolder\Callbacks\TransformCallback;
 use Phabalicious\Scaffolder\Options;
 use Phabalicious\Utilities\PluginDiscovery;
+use Phabalicious\Utilities\Utilities;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ScaffoldCommand extends ScaffoldBaseCommand
@@ -33,9 +35,17 @@ class ScaffoldCommand extends ScaffoldBaseCommand
         );
 
         $this->addOption(
+            'dry-run',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'if set, then the commands will be printed out, instead of executed.',
+            false
+        );
+
+        $this->addOption(
             'use-cached-tokens',
             null,
-            InputArgument::OPTIONAL,
+            InputOption::VALUE_OPTIONAL,
             'if set, then the tokens will be written into .phab-scaffold-tokens',
             false
         );
@@ -67,7 +77,8 @@ class ScaffoldCommand extends ScaffoldBaseCommand
         $options
             ->setAllowOverride(true)
             ->setSkipSubfolder(true)
-            ->setUseCacheTokens($input->getOption('use-cached-tokens'))
+            ->setUseCacheTokens(Utilities::hasBoolOptionSet($input, 'use-cached-tokens'))
+            ->setDryRun(Utilities::hasBoolOptionSet($input, 'dry-run'))
             ->addCallback('transform', [new TransformCallback(), 'handle'])
             ->setPluginRegistrationCallback(
                 function ($paths) use ($callback) {

--- a/src/Method/ArtifactsGitMethod.php
+++ b/src/Method/ArtifactsGitMethod.php
@@ -258,7 +258,7 @@ class ArtifactsGitMethod extends ArtifactsBaseMethod
             }
 
             $forced = (getenv("PHABALICIOUS_FORCE_GIT_ARTIFACT_DEPLOYMENT") ?: false) == "1";
-            $forced = $forced || Utilities::hasForceOption($context->getInput());
+            $forced = $forced || Utilities::hasBoolOptionSet($context->getInput(), 'force');
 
             if (!$forced &&
                 !$context->io()->confirm("Are you sure, you want to continue?", false)

--- a/src/Method/BaseMethod.php
+++ b/src/Method/BaseMethod.php
@@ -90,7 +90,13 @@ abstract class BaseMethod implements MethodInterface
 
     public function isRunningAppRequired(HostConfig $host_config, TaskContextInterface $context, string $task)
     {
-        $this->logger->info("Missing implementation for taskNeedsRunningApp: " . $task);
+        if ($task == 'appCreate') {
+            $stage = $context->get('currentStage');
+            if ($stage == 'checkConnectivity') {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/src/Method/DockerMethod.php
+++ b/src/Method/DockerMethod.php
@@ -89,7 +89,8 @@ class DockerMethod extends BaseMethod implements MethodInterface
 
     public function isRunningAppRequired(HostConfig $host_config, TaskContextInterface $context, string $task): bool
     {
-        return in_array($task, $this->getInternalTasks());
+        return parent::isRunningAppRequired($host_config, $context, $task)
+            || in_array($task, $this->getInternalTasks());
     }
 
     /**

--- a/src/Method/DrupalconsoleMethod.php
+++ b/src/Method/DrupalconsoleMethod.php
@@ -34,7 +34,8 @@ class DrupalconsoleMethod extends BaseMethod implements MethodInterface
 
     public function isRunningAppRequired(HostConfig $host_config, TaskContextInterface $context, string $task): bool
     {
-        return $task === 'drupalConsole';
+
+        return parent::isRunningAppRequired($host_config, $context, $task) || $task === 'drupalConsole';
     }
 
     private function getDrupalExec(string $root_folder, ShellProviderInterface $shell)

--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -179,7 +179,8 @@ class DrushMethod extends BaseMethod implements MethodInterface
 
     public function isRunningAppRequired(HostConfig $host_config, TaskContextInterface $context, string $task): bool
     {
-        return in_array($task, [
+        return parent::isRunningAppRequired($host_config, $context, $task) ||
+            in_array($task, [
             'drush',
             'backup',
             'restore',

--- a/src/Method/FilesMethod.php
+++ b/src/Method/FilesMethod.php
@@ -40,7 +40,8 @@ class FilesMethod extends BaseMethod implements MethodInterface
 
     public function isRunningAppRequired(HostConfig $host_config, TaskContextInterface $context, string $task): bool
     {
-        return in_array($task, ['putFile', 'getFile', 'backup', 'listBackups', 'restore', 'getFilesDump', 'copyFrom']);
+        return parent::isRunningAppRequired($host_config, $context, $task) ||
+            in_array($task, ['putFile', 'getFile', 'backup', 'listBackups', 'restore', 'getFilesDump', 'copyFrom']);
     }
 
     public function putFile(HostConfig $config, TaskContextInterface $context)

--- a/src/Method/GitMethod.php
+++ b/src/Method/GitMethod.php
@@ -67,7 +67,9 @@ class GitMethod extends BaseMethod implements MethodInterface
 
     public function isRunningAppRequired(HostConfig $host_config, TaskContextInterface $context, string $task): bool
     {
-        return in_array($task, ['version', 'deploy']);
+
+        return parent::isRunningAppRequired($host_config, $context, $task) ||
+            in_array($task, ['version', 'deploy']);
     }
 
     public function getTag(HostConfig $host_config, TaskContextInterface $context)

--- a/src/Method/K8sMethod.php
+++ b/src/Method/K8sMethod.php
@@ -66,7 +66,8 @@ class K8sMethod extends BaseMethod implements MethodInterface
 
     public function isRunningAppRequired(HostConfig $host_config, TaskContextInterface $context, string $task): bool
     {
-        return in_array($task, ['startRemoteAccess']);
+        return parent::isRunningAppRequired($host_config, $context, $task) ||
+            in_array($task, ['startRemoteAccess']);
     }
 
     public function getDefaultConfig(ConfigurationService $configuration_service, array $host_config): array

--- a/src/Method/PlatformMethod.php
+++ b/src/Method/PlatformMethod.php
@@ -44,7 +44,8 @@ class PlatformMethod extends BaseMethod
 
     public function isRunningAppRequired(HostConfig $host_config, TaskContextInterface $context, string $task): bool
     {
-        return in_array($task, ['deploy', 'reset', 'drush']);
+        return parent::isRunningAppRequired($host_config, $context, $task) ||
+            in_array($task, ['deploy', 'reset', 'drush']);
     }
 
     protected function runCommand(HostConfig $host_config, TaskContextInterface $context, string $command)

--- a/src/Method/RunCommandBaseMethod.php
+++ b/src/Method/RunCommandBaseMethod.php
@@ -52,6 +52,9 @@ abstract class RunCommandBaseMethod extends BaseMethod implements MethodInterfac
 
     public function isRunningAppRequired(HostConfig $host_config, TaskContextInterface $context, string $task): bool
     {
+        if (parent::isRunningAppRequired($host_config, $context, $task)) {
+            return true;
+        }
         if ($task !== $this->getName()) {
             return false;
         }

--- a/src/Method/ScriptMethod.php
+++ b/src/Method/ScriptMethod.php
@@ -58,7 +58,8 @@ class ScriptMethod extends BaseMethod implements MethodInterface
 
     public function isRunningAppRequired(HostConfig $host_config, TaskContextInterface $context, string $task): bool
     {
-        return in_array($task, ['runScript']);
+        return parent::isRunningAppRequired($host_config, $context, $task) ||
+            in_array($task, ['runScript']);
     }
 
     /**

--- a/src/Method/ScriptMethod.php
+++ b/src/Method/ScriptMethod.php
@@ -187,8 +187,8 @@ class ScriptMethod extends BaseMethod implements MethodInterface
      * @param array $replacements
      *
      * @return CommandResult|null
-     * @throws MissingScriptCallbackImplementation
-     * @throws UnknownReplacementPatternException
+     * @throws \Phabalicious\Exception\MissingScriptCallbackImplementation
+     * @throws \Phabalicious\Exception\UnknownReplacementPatternException
      */
     private function runScriptImpl(
         string $root_folder,
@@ -224,7 +224,7 @@ class ScriptMethod extends BaseMethod implements MethodInterface
             $result = Utilities::extractCallback($line);
             $callback_handled = false;
             if ($result) {
-                list($callback_name, $args) = $result;
+                [$callback_name, $args] = $result;
                 $callback_handled = $this->executeCallback($context, $callbacks, $callback_name, $args);
             }
             if (!$callback_handled) {

--- a/src/Method/SshMethod.php
+++ b/src/Method/SshMethod.php
@@ -42,7 +42,8 @@ class SshMethod extends BaseMethod implements MethodInterface
 
     public function isRunningAppRequired(HostConfig $host_config, TaskContextInterface $context, string $task): bool
     {
-        return in_array($task, ['shell']);
+        return parent::isRunningAppRequired($host_config, $context, $task) ||
+            in_array($task, ['shell']);
     }
 
     public function createShellProvider(array $host_config)

--- a/src/Scaffolder/CallbackOptions.php
+++ b/src/Scaffolder/CallbackOptions.php
@@ -12,6 +12,7 @@ use Phabalicious\Scaffolder\Callbacks\AssertNonZeroCallback;
 use Phabalicious\Scaffolder\Callbacks\AssertZeroCallback;
 use Phabalicious\Scaffolder\Callbacks\ConfirmCallback;
 use Phabalicious\Scaffolder\Callbacks\LogMessageCallback;
+use Phabalicious\Scaffolder\Callbacks\ScaffoldCallback;
 use Phabalicious\Scaffolder\Callbacks\SetDirectoryCallback;
 
 class CallbackOptions implements AlterableDataInterface
@@ -29,7 +30,8 @@ class CallbackOptions implements AlterableDataInterface
             ->addCallback(AssertContainsCallback::getName(), [new AssertContainsCallback(), 'handle'])
             ->addCallback(SetDirectoryCallBack::getName(), [new SetDirectoryCallBack(), 'handle'])
             ->addCallback(AlterYamlFileCallback::getName(), [new AlterYamlFileCallback(), 'handle'])
-            ->addCallback(AlterJsonFileCallback::getName(), [new AlterJsonFileCallback(), 'handle']);
+            ->addCallback(AlterJsonFileCallback::getName(), [new AlterJsonFileCallback(), 'handle'])
+            ->addCallback(ScaffoldCallback::getName(), [new ScaffoldCallback(), 'handle']);
 
         return $this;
     }

--- a/src/Scaffolder/Callbacks/ScaffoldCallback.php
+++ b/src/Scaffolder/Callbacks/ScaffoldCallback.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Phabalicious\Scaffolder\Callbacks;
+
+use Phabalicious\Method\TaskContextInterface;
+use Phabalicious\Scaffolder\Options;
+use Phabalicious\Scaffolder\Scaffolder;
+use Phabalicious\Utilities\Utilities;
+use Symfony\Component\Yaml\Yaml;
+
+class ScaffoldCallback extends BaseCallback implements CallbackInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public static function getName()
+    {
+        return 'scaffold';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function requires()
+    {
+        return '3.6';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(TaskContextInterface $context, ...$arguments)
+    {
+        $scaffold_url = array_shift($arguments);
+        $tokens = Utilities::mergeData($context->get('tokens', []), $this->getTokens($arguments));
+        $this->scaffold($context, $scaffold_url, $tokens);
+    }
+
+    public function scaffold(
+        TaskContextInterface $context,
+        string $scaffold_url,
+        $tokens
+    ) {
+        $options = new Options();
+        $options->setAllowOverride(true)
+            ->setUseCacheTokens(false);
+        $scaffolder = new Scaffolder($context->getConfigurationService());
+        $scaffolder->scaffold($scaffold_url, dirname($tokens['rootFolder']), $context, $tokens, $options);
+    }
+
+    private function getTokens(array $arguments):array
+    {
+        $result = [];
+        foreach ($arguments as $arg) {
+            [$key, $value] = explode("=", $arg, 2);
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+}

--- a/src/Scaffolder/Callbacks/ScaffoldCallback.php
+++ b/src/Scaffolder/Callbacks/ScaffoldCallback.php
@@ -31,21 +31,38 @@ class ScaffoldCallback extends BaseCallback implements CallbackInterface
      */
     public function handle(TaskContextInterface $context, ...$arguments)
     {
+        if (count($arguments) < 2) {
+            throw new \InvalidArgumentException(
+                'The scaffold callbacks requires 3 parameters: url, root_folder, project_folder'
+            );
+        }
         $scaffold_url = array_shift($arguments);
+        $scaffold_root_folder = array_shift($arguments);
         $tokens = Utilities::mergeData($context->get('tokens', []), $this->getTokens($arguments));
-        $this->scaffold($context, $scaffold_url, $tokens);
+        $this->scaffold($context, $scaffold_url, $scaffold_root_folder, $tokens);
     }
 
     public function scaffold(
         TaskContextInterface $context,
         string $scaffold_url,
+        string $scaffold_root_folder,
         $tokens
     ) {
+        $tokens['projectFolder'] = basename($scaffold_root_folder);
+        $tokens['rootFolder'] = $scaffold_root_folder;
+
         $options = new Options();
         $options->setAllowOverride(true)
+            ->setQuiet(true)
             ->setUseCacheTokens(false);
+
+        if ($existing_options = $context->get('options', false)) {
+            /** @var Options $existing_options */
+            $options->setDryRun($existing_options->isDryRun());
+        }
+
         $scaffolder = new Scaffolder($context->getConfigurationService());
-        $scaffolder->scaffold($scaffold_url, dirname($tokens['rootFolder']), $context, $tokens, $options);
+        $scaffolder->scaffold($scaffold_url, dirname($scaffold_root_folder), $context, $tokens, $options);
     }
 
     private function getTokens(array $arguments):array

--- a/src/Scaffolder/Options.php
+++ b/src/Scaffolder/Options.php
@@ -18,8 +18,6 @@ class Options extends CallbackOptions
 
     protected $skipSubfolder = false;
 
-    protected $callbacks = [];
-
     protected $useCacheTokens = true;
 
     protected $variables = [];

--- a/src/Scaffolder/Options.php
+++ b/src/Scaffolder/Options.php
@@ -20,6 +20,10 @@ class Options extends CallbackOptions
 
     protected $useCacheTokens = true;
 
+    protected $dryRun = false;
+
+    protected $quiet = false;
+
     protected $variables = [];
 
     /** @var ShellProviderInterface */
@@ -166,5 +170,43 @@ class Options extends CallbackOptions
     public function getShell(): ?ShellProviderInterface
     {
         return $this->shell;
+    }
+
+    /**
+     * Set dry-run flag.
+     *
+     * @param bool $flag
+     *
+     * @return $this
+     */
+    public function setDryRun(bool $flag): Options
+    {
+        $this->dryRun = $flag;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDryRun(): bool
+    {
+        return $this->dryRun;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isQuiet(): bool
+    {
+        return $this->quiet;
+    }
+
+    /**
+     * @param bool $quiet
+     */
+    public function setQuiet(bool $quiet): Options
+    {
+        $this->quiet = $quiet;
+        return $this;
     }
 }

--- a/src/ShellProvider/BaseShellProvider.php
+++ b/src/ShellProvider/BaseShellProvider.php
@@ -80,7 +80,7 @@ abstract class BaseShellProvider implements ShellProviderInterface
         $this->workingDir = $config['rootFolder'];
     }
 
-    public function getHostConfig(): HostConfig
+    public function getHostConfig(): ?HostConfig
     {
         return $this->hostConfig;
     }
@@ -207,5 +207,31 @@ abstract class BaseShellProvider implements ShellProviderInterface
         }
 
         return $this->putFile($immediate_file_name, $target_file_name, $context, $verbose);
+    }
+
+    /**
+     * Setup environment variables..
+     *
+     * @param array $environment
+     * @throws \Exception
+     */
+    public function applyEnvironment(array $environment)
+    {
+        $files = [
+            '/etc/profile',
+            '~/.bashrc'
+        ];
+        foreach ($files as $file) {
+            if ($this->exists($file)) {
+                $this->run(sprintf('. %s', $file), false, false);
+            }
+        }
+        $cmds = [];
+        foreach ($environment as $key => $value) {
+            $cmds[] = "export \"$key\"=\"$value\"";
+        }
+        if (!empty($cmds)) {
+            $this->run(implode(" && ", $cmds));
+        }
     }
 }

--- a/src/ShellProvider/DryRunShellProvider.php
+++ b/src/ShellProvider/DryRunShellProvider.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Phabalicious\ShellProvider;
+
+use Phabalicious\Configuration\ConfigurationService;
+use Phabalicious\Configuration\HostConfig;
+use Phabalicious\Exception\FailedShellCommandException;
+use Phabalicious\Method\TaskContextInterface;
+use Phabalicious\Utilities\SetAndRestoreObjProperty;
+use Phabalicious\Utilities\Utilities;
+use Phabalicious\Validation\ValidationErrorBagInterface;
+use Phabalicious\Validation\ValidationService;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\InputStream;
+use Symfony\Component\Process\Process;
+
+class DryRunShellProvider extends BaseShellProvider implements ShellProviderInterface
+{
+
+    const PROVIDER_NAME = 'dry-run';
+
+    protected $captured = [];
+
+    public function getName(): string
+    {
+        return self::PROVIDER_NAME;
+    }
+
+
+    public function getDefaultConfig(ConfigurationService $configuration_service, array $host_config): array
+    {
+        return [];
+    }
+
+
+    /**
+     * Run a command in the shell.
+     *
+     * @param string $command
+     * @param bool $capture_output
+     * @param bool $throw_exception_on_error
+     * @return CommandResult
+     * @throws FailedShellCommandException
+     * @throws \RuntimeException
+     */
+    public function run(string $command, $capture_output = false, $throw_exception_on_error = true): CommandResult
+    {
+        $command = sprintf("cd %s && %s", $this->getWorkingDir(), $this->expandCommand($command));
+        if (substr($command, -1) == ';') {
+            $command = substr($command, 0, -1);
+        }
+        $this->captured[] = $command;
+        if ($this->output) {
+            $saved = $this->output->getVerbosity();
+            $this->output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
+            $this->output->writeln($command);
+            $this->output->setVerbosity($saved);
+        }
+
+        $cr = new CommandResult(0, []);
+        if ($cr->failed() && !$capture_output && $throw_exception_on_error) {
+            $cr->throwException(sprintf('`%s` failed!', $command));
+        }
+        return $cr;
+    }
+
+    public function exists($file): bool
+    {
+        return true;
+    }
+
+    public function getFile(string $source, string $dest, TaskContextInterface $context, bool $verbose = false): bool
+    {
+        throw new \RuntimeException("getFile not implemented!");
+    }
+
+    public function putFile(string $source, string $dest, TaskContextInterface $context, bool $verbose = false): bool
+    {
+        throw new \RuntimeException("putFile not implemented!");
+    }
+
+    public function startRemoteAccess(
+        string $ip,
+        int $port,
+        string $public_ip,
+        int $public_port,
+        HostConfig $config,
+        TaskContextInterface $context
+    ) {
+        throw new \RuntimeException("startRemoteAccess not implemented!");
+    }
+
+    public function getShellCommand(array $program_to_call, ShellOptions $options): array
+    {
+        throw new \RuntimeException("getShellCommand not implemented!");
+    }
+
+    public function createShellProcess(array $command = [], ShellOptions $options = null): Process
+    {
+        throw new \RuntimeException("createShellProcess not implemented!");
+    }
+
+    public function createTunnelProcess(HostConfig $target_config, array $prefix = [])
+    {
+        throw new \RuntimeException("createTunnelProcess not implemented!");
+    }
+
+    public function wrapCommandInLoginShell(array $command)
+    {
+        return $command;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCapturedCommands(): array
+    {
+        return $this->captured;
+    }
+}

--- a/src/ShellProvider/LocalShellProvider.php
+++ b/src/ShellProvider/LocalShellProvider.php
@@ -110,7 +110,9 @@ class LocalShellProvider extends BaseShellProvider implements ShellProviderInter
         }
 
         $shell_executable = $this->hostConfig['shellExecutable'];
-        $this->process = $this->createShellProcess([$shell_executable]);
+        $options = new ShellOptions();
+        $options->setQuiet(false);
+        $this->process = $this->createShellProcess([$shell_executable], $options);
 
         $this->input = new InputStream();
         $this->process->setInput($this->input);
@@ -210,6 +212,11 @@ class LocalShellProvider extends BaseShellProvider implements ShellProviderInter
         if ($this->process->isTerminated()) {
             $this->logger->log($this->loglevel->get(), 'Local shell terminated unexpected, will start a new one!');
             $error_output = trim($this->process->getErrorOutput());
+            $output = trim($this->process->getOutput());
+
+            if (!empty($output)) {
+                $this->logger->log($this->errorLogLevel->get(), $output);
+            }
             if (!empty($error_output)) {
                 $this->logger->log($this->errorLogLevel->get(), $error_output);
             }

--- a/src/ShellProvider/LocalShellProvider.php
+++ b/src/ShellProvider/LocalShellProvider.php
@@ -239,35 +239,10 @@ class LocalShellProvider extends BaseShellProvider implements ShellProviderInter
         return $cr;
     }
 
-    /**
-     * Setup environment variables..
-     *
-     * @param array $environment
-     * @throws \Exception
-     */
-    public function applyEnvironment(array $environment)
-    {
-        $files = [
-            '/etc/profile',
-            '~/.bashrc'
-        ];
-        foreach ($files as $file) {
-            if ($this->exists($file)) {
-                $this->run(sprintf('. %s', $file), false, false);
-            }
-        }
-        $cmds = [];
-        foreach ($environment as $key => $value) {
-            $cmds[] = "export \"$key\"=\"$value\"";
-        }
-        if (!empty($cmds)) {
-            $this->run(implode(" && ", $cmds));
-        }
-    }
 
-    public function getShellCommand(array $command, ShellOptions $options):array
+    public function getShellCommand(array $program_to_call, ShellOptions $options):array
     {
-        return $command;
+        return $program_to_call;
     }
 
     public function exists($file): bool

--- a/src/ShellProvider/ShellProviderInterface.php
+++ b/src/ShellProvider/ShellProviderInterface.php
@@ -20,7 +20,7 @@ interface ShellProviderInterface extends LogLevelStackGetterInterface
 
     public function setHostConfig(HostConfig $config);
 
-    public function getHostConfig(): HostConfig;
+    public function getHostConfig(): ?HostConfig;
 
     public function getWorkingDir(): string;
 

--- a/src/ShellProvider/TunnelHelper/TunnelHelperFactory.php
+++ b/src/ShellProvider/TunnelHelper/TunnelHelperFactory.php
@@ -27,7 +27,7 @@ class TunnelHelperFactory
         }
         $this->creatingTunnel = true;
 
-        if (!in_array($task, ['about', 'doctor', 'sshCommand'])) {
+        if ($context->getConfigurationService()->isRunningAppRequired($config, $context, $task)) {
             $this->createLocalToHostTunnel($config, $context);
         }
         if (in_array($task, ['copyFrom'])) {

--- a/src/Utilities/AppDefaultStages.php
+++ b/src/Utilities/AppDefaultStages.php
@@ -11,6 +11,7 @@ class AppDefaultStages
         'prepareDestination',
         'installCode',
         'spinUp',
+        'checkConnectivity',
         'installDependencies',
         'install',
     ];

--- a/src/Utilities/Utilities.php
+++ b/src/Utilities/Utilities.php
@@ -257,7 +257,14 @@ class Utilities
         return preg_replace('/\s|\.|\,|_|\-|:|\//', $replacement, strtolower($str));
     }
 
-    public static function isAssocArray($arr)
+    /**
+     * Check if $arr is an associative array.
+     *
+     * @param mixed $arr
+     *
+     * @return bool
+     */
+    public static function isAssocArray($arr): bool
     {
         if (!is_array($arr) || array() === $arr) {
             return false;
@@ -265,7 +272,7 @@ class Utilities
         return array_keys($arr) !== range(0, count($arr) - 1);
     }
 
-    public static function prependRootFolder($rootFolder, $subfolder)
+    public static function prependRootFolder($rootFolder, $subfolder): string
     {
         if (strpos($subfolder, $rootFolder) === false) {
             return $rootFolder . $subfolder;
@@ -274,7 +281,7 @@ class Utilities
         return $subfolder;
     }
 
-    public static function cleanupString($identifier)
+    public static function cleanupString($identifier): string
     {
         $identifier = trim($identifier);
 
@@ -296,7 +303,7 @@ class Utilities
         return strtolower($identifier);
     }
 
-    public static function getRelativePath($from, $to)
+    public static function getRelativePath($from, $to): string
     {
         // some compatibility fixes for Windows paths
         $from = is_dir($from) ? rtrim($from, '\/') . '/' : $from;
@@ -381,7 +388,7 @@ class Utilities
     }
 
 
-    public static function generateUUID()
+    public static function generateUUID(): string
     {
         return bin2hex(openssl_random_pseudo_bytes(4)) . '-' .
             bin2hex(openssl_random_pseudo_bytes(2)) . '-' .
@@ -394,7 +401,7 @@ class Utilities
      * @param array $tokens
      * @return array
      */
-    public static function getReplacements($tokens): array
+    public static function getReplacements(array $tokens): array
     {
         $replacements = [];
         foreach ($tokens as $key => $value) {
@@ -421,16 +428,19 @@ class Utilities
      *
      * @return string
      */
-    public static function getUserFolder()
+    public static function getUserFolder(): string
     {
         $uid = posix_getuid();
         return posix_getpwuid($uid)['dir'];
     }
 
     /**
-     * Check if the force-option is set.
+     * Check if the given named option is set.
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input
+     *   The input.
+     * @param string $name
+     *   The name of the option.
      *
      * @return bool
      */

--- a/src/Utilities/Utilities.php
+++ b/src/Utilities/Utilities.php
@@ -434,9 +434,9 @@ class Utilities
      *
      * @return bool
      */
-    public static function hasForceOption(InputInterface $input): bool
+    public static function hasBoolOptionSet(InputInterface $input, string $name): bool
     {
-        $option = $input->getOption('force');
+        $option = $input->getOption($name);
 
         // Testing for valueless options is tricky in symfony. That is why we test for
         // `is_null` (has no option value, e.g. `--force`) or `!empty()`, e.g. `--force=1`

--- a/src/Utilities/Utilities.php
+++ b/src/Utilities/Utilities.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 class Utilities
 {
 
-    const FALLBACK_VERSION = '3.5.33';
+    const FALLBACK_VERSION = '3.6.0';
     const COMBINED_ARGUMENTS = 'combined';
     const UNNAMED_ARGUMENTS = 'unnamedArguments';
 

--- a/tests/ScaffoldTest.php
+++ b/tests/ScaffoldTest.php
@@ -130,6 +130,9 @@ class ScaffoldTest extends PhabTestCase
         $this->assertEquals("d-overridden", $yaml['c']['d']);
     }
 
+    /**
+     * @group docker
+     */
     public function testScaffoldCallback()
     {
 
@@ -152,6 +155,12 @@ class ScaffoldTest extends PhabTestCase
         $this->assertEquals(0, $result->getExitCode());
 
         $json = json_decode(file_get_contents($this->getCwd() . '/test-scaffold-callback/composer.json'), true);
+
+        $this->assertEquals('phabalicious/helloworld', $json['name']);
+        $this->assertArrayHasKey('phpro/grumphp-shim', $json['require-dev']);
+        $this->assertArrayHasKey('drupal/coder', $json['require-dev']);
+
+        $json = json_decode(file_get_contents($this->getCwd() . '/test-scaffold-callback/second/composer.json'), true);
 
         $this->assertArrayHasKey('phpro/grumphp-shim', $json['require-dev']);
         $this->assertArrayHasKey('drupal/coder', $json['require-dev']);

--- a/tests/ScaffoldTest.php
+++ b/tests/ScaffoldTest.php
@@ -129,4 +129,31 @@ class ScaffoldTest extends PhabTestCase
         $this->assertEquals("b-overridden", $yaml['b']);
         $this->assertEquals("d-overridden", $yaml['c']['d']);
     }
+
+    public function testScaffoldCallback()
+    {
+
+        $scaffolder = new Scaffolder($this->configuration);
+        $context = $this->createContext();
+        $options = new Options();
+        $options->setAllowOverride(true)
+            ->setUseCacheTokens(false);
+
+        $result = $scaffolder->scaffold(
+            $this->getCwd() . '/assets/scaffolder-test/scaffold-callback.yml',
+            $this->getcwd(),
+            $context,
+            [
+                'name' => 'test-scaffold-callback',
+            ],
+            $options
+        );
+
+        $this->assertEquals(0, $result->getExitCode());
+
+        $json = json_decode(file_get_contents($this->getCwd() . '/test-scaffold-callback/composer.json'), true);
+
+        $this->assertArrayHasKey('phpro/grumphp-shim', $json['require-dev']);
+        $this->assertArrayHasKey('drupal/coder', $json['require-dev']);
+    }
 }

--- a/tests/assets/app-create-tests/fabfile.yaml
+++ b/tests/assets/app-create-tests/fabfile.yaml
@@ -1,5 +1,13 @@
 name: app-create-tests
 
+appStages:
+    # We use cusomt stages to remove checkConnectivity, as this tries to connect to the inner app.
+    create:
+        -  'prepareDestination'
+        - 'installCode'
+        - 'spinUp'
+        - 'installDependencies'
+        - 'install'
 needs:
   - script
   - docker

--- a/tests/assets/app-create-tests/fabfile.yaml
+++ b/tests/assets/app-create-tests/fabfile.yaml
@@ -1,7 +1,7 @@
 name: app-create-tests
 
 appStages:
-    # We use cusomt stages to remove checkConnectivity, as this tries to connect to the inner app.
+    # We use custom stages to remove checkConnectivity, as this tries to connect to the inner app.
     create:
         -  'prepareDestination'
         - 'installCode'

--- a/tests/assets/scaffolder-test/scaffold-callback.yml
+++ b/tests/assets/scaffolder-test/scaffold-callback.yml
@@ -3,9 +3,16 @@ requires: 3.0
 questions: []
 assets: []
 
+variables:
+    secondFolder: "%rootFolder%/second"
+
 scaffold:
-  - echo %rootFolder%
-  - cd %rootFolder%; composer init --name phabalicious/helloword -n
-  - scaffold("https://config.factorial.io/scaffold/precommit-hooks/drupal/1.0/index.yml", "a=1", "b=2")
+  - mkdir -p %rootFolder%
+  - set_directory(%rootFolder%)
+  - git init
+  - composer init --name phabalicious/helloworld -n
+  - scaffold("https://config.factorial.io/scaffold/precommit-hooks/drupal/1.0/index.yml", %rootFolder%)
+  - mkdir %secondFolder%
+  - scaffold("https://config.factorial.io/scaffold/precommit-hooks/drupal/1.0/index.yml", %secondFolder%)
 
 

--- a/tests/assets/scaffolder-test/scaffold-callback.yml
+++ b/tests/assets/scaffolder-test/scaffold-callback.yml
@@ -1,0 +1,11 @@
+requires: 3.0
+
+questions: []
+assets: []
+
+scaffold:
+  - echo %rootFolder%
+  - cd %rootFolder%; composer init --name phabalicious/helloword -n
+  - scaffold("https://config.factorial.io/scaffold/precommit-hooks/drupal/1.0/index.yml", "a=1", "b=2")
+
+


### PR DESCRIPTION
… while scaffolding (inception!)

an example scaffold.yml could look like

```yaml
questions: []
assets: []
variables: 
themeFolder: "%rootFolder%/web/themes/custom/some_frontend"

scaffold:
  - scaffold("http://foo.bar/d8.yml", "%rootFolder%")
  - scaffold("http://foo.bar/d8-theme.yml", "%themeFolder%")
  - scaffold("http://foo.bar/d8-module.yml", "%rootFolder%/web/modules/custom/d8-module")
```

It adds also a new option for the `scaffold`-command called `--dry-run` which will output the commands instead of running them.

The PR contain also updates to the documentation and some bugfixes in regards to app:create and app:destroy and the readiness check if a task needs a running app.