### PR TITLE
Remove double --namespace from k8s methods

### DIFF
--- a/src/Method/K8sMethod.php
+++ b/src/Method/K8sMethod.php
@@ -300,10 +300,9 @@ class K8sMethod extends BaseMethod implements MethodInterface
 
         $this->kubectlShell->pushWorkingDir($project_folder);
         $cmd = sprintf(
-            '%s %s --namespace %s',
+            '%s %s',
             $this->expandCmd($host_config),
-            $command,
-            $kube_config['namespace']
+            $command
         );
         $result = $this->kubectlShell->run($cmd, $capture_output);
         $this->kubectlShell->popWorkingDir();


### PR DESCRIPTION
The `--namespace` is added twice to the kubectl method and the second time comes after the command. This makes passing parameters to commands impossible. For example

```
phab --config=CONFIG k8s kubectl -- exec POD -- ls -la
```

is

```
kubectl ... --namespace NAMESPACE exec POD -- ls -la --namespace NAMESPACE
```
