### PR TITLE
Support for 1password connect

### DIFF
--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -56,7 +56,7 @@ Phab will resolve the references on runtime and try to get the secret from
 
 ## Using 1Password CLI
 
-Make sure, that you have `op` up and running, ([Docs here](https://1password.com/downloads/command-line/)) and your secret has set a `onePasswordId` as in the following example:
+Make sure that you have `op` up and running (see the [documentation](https://1password.com/downloads/command-line/)), and your secret has set an `onePasswordId` as in the following example:
 
 ```yaml
 

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -25,6 +25,7 @@ secrets:
   mysql-password:
     question: Please provide the Mysql password for the cluster
     onePasswordId: 1234418718212s121
+    onePasswordVaultId: 768131213124
 ````
 
 
@@ -49,8 +50,51 @@ Phab will resolve the references on runtime and try to get the secret from
   * from the command line via the option `--secret`, e.g. `--secret registry-password=123 --secret mysql-password=iamsecret`
   * from the local password file (see below)
   * from the 1password cli if it is installed, and the secret declaration has a `onePasswordId` set. You need to be signed into 1password via the cli beforehand. (See the [documentation](https://support.1password.com/command-line-getting-started/))
+
+  * If a `onePasswordVaultId` is set and a global config for `onePassword` is available then phab will try to lookup the secret using 1password connect. (See below)
   * As a last resort, the user get prompted for the password.
 
+## Using 1Password CLI
+
+Make sure, that you have `op` up and running, ([Docs here](https://1password.com/downloads/command-line/)) and your secret has set a `onePasswordId` as in the following example:
+
+```yaml
+
+secrets:
+  mysql-password:
+    question: Please provide the Mysql password for the cluster
+    onePasswordId: 1234418718212s121
+```
+
+(You can get the id either by querying the database with `op`, or online via the web-ui).
+
+1. Log into 1password cli with `eval (op signin <YOUR_TEAM_NAME>)`
+2. Run your phab command.
+
+If you are not logged in before phab needs the secret, the command will fail with an error message. You can override the path to the `op`-executable by setting the environment variable `PHAB_OP_FILE_PATH`.
+
+## Using 1password connect
+
+Make sure, you have a runnning 1password-connect-instance (See 1passwords [documentation](https://support.1password.com/secrets-automation/)). Phab needs the api-endpoint and the token for the service to authenticate against it. Best practice is to store this data in an override-file either in your home-folder or up to 5 levels up from your project-folder. E.g. in `../../fabfile.local.override.yaml`
+
+```yaml
+onePassword:
+  endpoint: https://vault.your-domain.tld
+  token: <your-bearer-token>
+```
+
+Then your secret needs to reference both the id and the vault-id as with this example:
+
+
+````yaml
+secrets:
+  mysql-password:
+    question: Please provide the Mysql password for the cluster
+    onePasswordId: 1234418718212s121
+    onePasswordVaultId: 768131213124
+````
+
+Then just run your command as usual, phab will try to resolve the secret from 1password connect and use it.
 
 ## FTP-passwords
 

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -68,14 +68,14 @@ secrets:
 
 (You can get the id either by querying the database with `op`, or online via the web-ui).
 
-1. Log into 1password cli with `eval (op signin <YOUR_TEAM_NAME>)`
+1. Log into 1password cli with `eval (op signin <YOUR_TEAM_NAME>)` (this is for the fish-shell, other shells might need a different syntax)
 2. Run your phab command.
 
 If you are not logged in before phab needs the secret, the command will fail with an error message. You can override the path to the `op`-executable by setting the environment variable `PHAB_OP_FILE_PATH`.
 
 ## Using 1password connect
 
-Make sure, you have a runnning 1password-connect-instance (See 1passwords [documentation](https://support.1password.com/secrets-automation/)). Phab needs the api-endpoint and the token for the service to authenticate against it. Best practice is to store this data in an override-file either in your home-folder or up to 5 levels up from your project-folder. E.g. in `../../fabfile.local.override.yaml`
+Make sure, you have a runnning 1password-connect-instance (See 1passwords [documentation](https://support.1password.com/secrets-automation/)). Phab needs the api-endpoint and the token for the service to authenticate against it. Best practice is to store this data in an override-file either in your home-folder or up to 5 levels up from your project-folder. E.g. in `../../fabfile.local.override.yaml` **DO NOT COMMIT THE TOKEN INTO THE REPOSITORY**
 
 ```yaml
 onePassword:

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -71,7 +71,9 @@ secrets:
 1. Log into 1password cli with `eval (op signin <YOUR_TEAM_NAME>)` (this is for the fish-shell, other shells might need a different syntax)
 2. Run your phab command.
 
-If you are not logged in before phab needs the secret, the command will fail with an error message. You can override the path to the `op`-executable by setting the environment variable `PHAB_OP_FILE_PATH`.
+If you are not logged in before phab needs the secret, the command will fail with an error message. 
+
+You can override the path to the `op`-executable by setting the environment variable `PHAB_OP_FILE_PATH`.
 
 ## Using 1password connect
 

--- a/docs/passwords.md
+++ b/docs/passwords.md
@@ -51,7 +51,7 @@ Phab will resolve the references on runtime and try to get the secret from
   * from the local password file (see below)
   * from the 1password cli if it is installed, and the secret declaration has a `onePasswordId` set. You need to be signed into 1password via the cli beforehand. (See the [documentation](https://support.1password.com/command-line-getting-started/))
 
-  * If a `onePasswordVaultId` is set and a global config for `onePassword` is available then phab will try to lookup the secret using 1password connect. (See below)
+  * If a `onePasswordVaultId` is set and a global config for `onePassword` is available, then phab will try to lookup the secret using 1password connect. (See below)
   * As a last resort, the user get prompted for the password.
 
 ## Using 1Password CLI

--- a/src/Utilities/PasswordManager.php
+++ b/src/Utilities/PasswordManager.php
@@ -236,7 +236,7 @@ class PasswordManager implements PasswordManagerInterface
             $validation_service = new ValidationService($onepassword_connect, $errors, 'onePassword');
             $validation_service->hasKeys([
                 'token' => 'The access token to authenticate against onePassword connect',
-                'endpoint' => 'The onepassword api endpoint to connect to'
+                'endpoint' => 'The onePassword api endpoint to connect to'
             ]);
 
             if ($errors->hasErrors()) {


### PR DESCRIPTION
1password connect provides a rest-api to interact with a set of vaults via a rest service. This PR will add support for querying an arbitrary installation to gather a secret.

Needed changes for the configuration:

```
secrets:
  a: 
    onePasswordId: <id of the item>
    onePasswordVaultId: <id of the vault>
```

Then you need to inject globally the onepassword config, e.g. in a `fabfile.local.yaml`

```
onePassword:
  endpoint: <onepassword-connect-url>
  token: <JWT-token>
```

then it should work out of the box.
