### PR TITLE
Feature/skip drop db and new database command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -224,7 +224,7 @@ This will restore a backup-set. A backup-set consists typically of a database-du
 
 * `git` git will checkout the given hash encoded in the filename.
 * `files` all files will be restored. An existing files-folder will be renamed for safety reasons.
-* `drush` will import the database-dump.
+* `mysql`, `sqlite` will import the database-dump.
 * `restic` will restore the files and saved db dumps (You might need to run another restore to restore a sql-dump)
 
 ## get:backup
@@ -245,24 +245,27 @@ This command will copy a remote backup-set to your local computer into the curre
 
 ``` bash
 phab --config=<dest-config> copy-from <source-config> <what>
+phab --config=<dest-config> copy-from <source-config> <what> --skip-reset
+phab --config=<dest-config> copy-from <source-config> <what> --skip-drop-db
 ```
 
 This command will copy all files via rsync from `source-config` to `dest-config` and will dump the database from `source-config` and restore it to `dest-config` when `<what>` is omitted.
 
-After that the `reset`-command gets executed. This is the ideal command to copy a complete installation from one host to another.
+After that the `reset`-command gets executed (if `--skip-reset` is not specified). This is the ideal command to copy a complete installation from one host to another.
 
-You can limit what to copy by adding `db` or `files`  as arguments.
+You can limit what to copy by adding `db` or `files`  as arguments. `--skip-drop-db` will instrcut phab to not drop the db before the import.
 
 **Available methods**
 
 * `ssh` will create all necessary tunnels to access the hosts.
 * `files` will rsync all new and changed files from source to dest
-* `drush` will dump the database and restore it on the dest-host.
+* `mysql`, `sqlite` will dump the database and restore it on the dest-host.
 
 **Examples**
 
 * `phab -cmbb copy-from remote-host` will copy db and files from `remote-host` to `mbb`
 * `phab -cmbb copy-from remote-host db` will copy only the db  from `remote-host` to `mbb`
+* `phab -cmbb copy-from remote-host db --skip-reset --skip-drop-db` will copy only the db  from `remote-host` to `mbb`, without dropping the db and without running the reset task afterwards.
 * `phab -cmbb copy-from remote-host files` will copy only the files from `remote-host` to `mbb`
 
 
@@ -350,20 +353,23 @@ Get a current dump of the remote database and copy it to the local machine into 
 
 **Available methods**
 
-* currently only implemented for the `drush`-method
+* `mysql`
+* `sqlite`
 
 
 ## restore:sql-from-file
 
 ``` bash
 phab --config=<config> restore:sql-from-file <path-to-local-sql-dump>
+phab --config=<config> restore:sql-from-file <path-to-local-sql-dump> --skip-drop-db
 ```
 
-This command will copy the dump-file `path-to-local-sql-dump` to the remote machine and import it into the database.
+This command will copy the dump-file `path-to-local-sql-dump` to the remote machine, drop the database (if the `--skip-drop-db`-option is not passed) and import it into the database.
 
 **Available methods**
 
-* currently only implemented for the `drush`-method
+* `mysql`
+* `sqlite`
 
 
 ## script
@@ -584,3 +590,13 @@ Runs a laravel artisan command
 phab -chost artisan db:seed
 phab -chost artisan migrate
 ```
+
+## db
+
+```bash
+phab -chost database install
+phab -chost database drop
+```
+
+This command allows you to run commands on the db, `install` will create a new database, `drop` will drop all tables.
+

--- a/src/Command/DatabaseCommand.php
+++ b/src/Command/DatabaseCommand.php
@@ -1,7 +1,8 @@
-<?php
+<?php /** @noinspection PhpRedundantCatchClauseInspection */
 
 namespace Phabalicious\Command;
 
+use Phabalicious\Configuration\ConfigurationService;
 use Phabalicious\Exception\BlueprintTemplateNotFoundException;
 use Phabalicious\Exception\FabfileNotFoundException;
 use Phabalicious\Exception\FabfileNotReadableException;
@@ -10,28 +11,33 @@ use Phabalicious\Exception\MismatchedVersionException;
 use Phabalicious\Exception\MissingDockerHostConfigException;
 use Phabalicious\Exception\ShellProviderNotFoundException;
 use Phabalicious\Exception\TaskNotFoundInMethodException;
-use Phabalicious\ShellProvider\ShellProviderInterface;
+use Phabalicious\Method\MethodFactory;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
-class GetSqlDumpCommand extends BaseCommand
+class DatabaseCommand extends BaseCommand
 {
-
     protected function configure()
     {
-        $this
-            ->setName('get:sql-dump')
-            ->setDescription('Get a current dump of the database')
-            ->setHelp('Gets a dump of the database and copies it to your local computer');
-        $this->setAliases(['getSQLDump']);
         parent::configure();
+        $this
+            ->setName('db')
+            ->setDescription('Interact with a database')
+            ->setHelp('Run specific commands against the database');
+        $this->addArgument(
+            'what',
+            InputArgument::REQUIRED,
+            'The subcommand to execute on the database'
+        );
+
+        $this->setAliases(['getFile']);
     }
 
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return int
+     * @return int|null
      * @throws BlueprintTemplateNotFoundException
      * @throws FabfileNotFoundException
      * @throws FabfileNotReadableException
@@ -48,31 +54,19 @@ class GetSqlDumpCommand extends BaseCommand
         }
 
         $context = $this->getContext();
-
-        $this->getMethods()->runTask('getSQLDump', $this->getHostConfig(), $context);
-        $to_copy = $context->getResult('files', []);
-
-        /** @var ShellProviderInterface $shell */
-        $shell = $context->get('shell', $this->getHostConfig()->shell());
-        $files = [];
-        foreach ($to_copy as $file) {
-            if ($shell->getFile(
-                $file,
-                getcwd() . '/' . basename($file),
-                $context
-            )) {
-                $files[] = basename($file);
-            }
-            $shell->run(sprintf('rm %s', $file));
+        $what = strtolower($input->getArgument('what'));
+        if (!in_array($what, ['drop', 'install'])) {
+            throw new \RuntimeException(sprintf('Unsupported database command: `%s`', $what));
         }
 
+        $context->set('what', $what);
 
-        if (count($files) > 0) {
-            $io = new SymfonyStyle($input, $output);
-            $io->title('Copied dumps to:');
-            $io->listing($files);
+        $this->getMethods()->runTask('database', $this->getHostConfig(), $context);
+
+        $return_code = $context->getResult('exitCode', 0);
+        if ($return_code === 0) {
+            $context->io()->success(sprintf('Database-command `%s` executed successfully!', $what));
         }
-
-        return 0;
+        return $return_code;
     }
 }

--- a/src/Command/DatabaseCommand.php
+++ b/src/Command/DatabaseCommand.php
@@ -23,6 +23,7 @@ class DatabaseCommand extends BaseCommand
         parent::configure();
         $this
             ->setName('db')
+            ->setAliases(['database'])
             ->setDescription('Interact with a database')
             ->setHelp('Run specific commands against the database');
         $this->addArgument(

--- a/src/Command/RestoreSqlFromFileCommand.php
+++ b/src/Command/RestoreSqlFromFileCommand.php
@@ -2,9 +2,20 @@
 
 namespace Phabalicious\Command;
 
-use Phabalicious\Method\TaskContext;
+use InvalidArgumentException;
+use Phabalicious\Exception\BlueprintTemplateNotFoundException;
+use Phabalicious\Exception\FabfileNotFoundException;
+use Phabalicious\Exception\FabfileNotReadableException;
+use Phabalicious\Exception\MethodNotFoundException;
+use Phabalicious\Exception\MismatchedVersionException;
+use Phabalicious\Exception\MissingDockerHostConfigException;
+use Phabalicious\Exception\ShellProviderNotFoundException;
+use Phabalicious\Exception\TaskNotFoundInMethodException;
+use Phabalicious\Method\DatabaseMethod;
+use Phabalicious\Utilities\Utilities;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class RestoreSqlFromFileCommand extends BaseCommand
@@ -21,6 +32,14 @@ class RestoreSqlFromFileCommand extends BaseCommand
             InputArgument::REQUIRED,
             'The file containing the sql-dump'
         );
+        $this->addOption(
+            'skip-drop-db',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Skip dropping the db before running the import',
+            false
+        );
+
         $this->setAliases(['restoreSQLFromFile']);
     }
 
@@ -29,14 +48,14 @@ class RestoreSqlFromFileCommand extends BaseCommand
      * @param OutputInterface $output
      *
      * @return int|null
-     * @throws \Phabalicious\Exception\BlueprintTemplateNotFoundException
-     * @throws \Phabalicious\Exception\FabfileNotFoundException
-     * @throws \Phabalicious\Exception\FabfileNotReadableException
-     * @throws \Phabalicious\Exception\MethodNotFoundException
-     * @throws \Phabalicious\Exception\MismatchedVersionException
-     * @throws \Phabalicious\Exception\MissingDockerHostConfigException
-     * @throws \Phabalicious\Exception\ShellProviderNotFoundException
-     * @throws \Phabalicious\Exception\TaskNotFoundInMethodException
+     * @throws BlueprintTemplateNotFoundException
+     * @throws FabfileNotFoundException
+     * @throws FabfileNotReadableException
+     * @throws MethodNotFoundException
+     * @throws MismatchedVersionException
+     * @throws MissingDockerHostConfigException
+     * @throws ShellProviderNotFoundException
+     * @throws TaskNotFoundInMethodException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -47,7 +66,7 @@ class RestoreSqlFromFileCommand extends BaseCommand
         $context = $this->getContext();
         $file = $input->getArgument('file');
         if (!file_exists($file)) {
-            throw new \InvalidArgumentException('Could not find file at `' . $file . '`');
+            throw new InvalidArgumentException('Could not find file at `' . $file . '`');
         }
 
         $host_config = $this->getHostConfig();
@@ -61,6 +80,7 @@ class RestoreSqlFromFileCommand extends BaseCommand
 
         $shell->putFile($file, $dest, $context);
         $context->set('source', $dest);
+        $context->set(DatabaseMethod::DROP_DATABASE, !Utilities::hasBoolOptionSet($input, 'skip-drop-db'));
 
         $this->getMethods()->runTask('restoreSqlFromFile', $host_config, $context);
 

--- a/src/Method/DatabaseMethod.php
+++ b/src/Method/DatabaseMethod.php
@@ -364,15 +364,13 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
 
         switch ($what) {
             case 'install':
-                $this->install($host_config, $context);
+                return $this->install($host_config, $context);
                 break;
 
             case 'drop':
-                $this->dropDatabase($host_config, $context, $shell, $data);
+                return $this->dropDatabase($host_config, $context, $shell, $data);
                 break;
-
-            default:
-                throw new RuntimeException(sprintf("Unknown database command `%s`", $what));
         }
+        throw new RuntimeException(sprintf("Unknown database command `%s`", $what));
     }
 }

--- a/src/Method/DatabaseMethod.php
+++ b/src/Method/DatabaseMethod.php
@@ -2,17 +2,23 @@
 
 namespace Phabalicious\Method;
 
+use InvalidArgumentException;
 use Phabalicious\Configuration\ConfigurationService;
 use Phabalicious\Configuration\HostConfig;
+use Phabalicious\Exception\FailedShellCommandException;
+use Phabalicious\Exception\MethodNotFoundException;
+use Phabalicious\Exception\TaskNotFoundInMethodException;
 use Phabalicious\Exception\ValidationFailedException;
 use Phabalicious\ShellProvider\ShellProviderInterface;
 use Phabalicious\Validation\ValidationErrorBag;
 use Phabalicious\Validation\ValidationErrorBagInterface;
 use Phabalicious\Validation\ValidationService;
+use RuntimeException;
 
 abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterface
 {
     const DATABASE_CREDENTIALS = 'databaseCredentials';
+    const DROP_DATABASE = "dropDatabase";
 
     public function getDefaultConfig(ConfigurationService $configuration_service, array $host_config): array
     {
@@ -31,8 +37,8 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
     }
 
     /**
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
      * @param string $task
      *
      * @return bool
@@ -55,7 +61,7 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
 
     /**
      * @param array $config
-     * @param \Phabalicious\Validation\ValidationErrorBagInterface $errors
+     * @param ValidationErrorBagInterface $errors
      */
     public function validateConfig(array $config, ValidationErrorBagInterface $errors)
     {
@@ -71,8 +77,8 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
     }
 
     /**
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
      */
     public function backup(HostConfig $host_config, TaskContextInterface $context)
     {
@@ -96,8 +102,8 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
     }
 
     /**
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
      */
     public function getSQLDump(HostConfig $host_config, TaskContextInterface $context)
     {
@@ -128,7 +134,7 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
      * @param HostConfig $host_config
      * @param TaskContextInterface $context
      *
-     * @throws \Phabalicious\Exception\FailedShellCommandException
+     * @throws FailedShellCommandException
      */
     public function restore(HostConfig $host_config, TaskContextInterface $context)
     {
@@ -148,7 +154,8 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
                 $host_config,
                 $context,
                 $shell,
-                $host_config['backupFolder'] . '/' . $elem['file']
+                $host_config['backupFolder'] . '/' . $elem['file'],
+                true
             );
 
             if (!$result->succeeded()) {
@@ -162,18 +169,24 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
     }
 
     /**
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
      */
     public function restoreSqlFromFile(HostConfig $host_config, TaskContextInterface $context)
     {
         $file = $context->get('source', false);
         if (!$file) {
-            throw new \InvalidArgumentException('Missing file parameter');
+            throw new InvalidArgumentException('Missing file parameter');
         }
         $shell = $this->getShell($host_config, $context);
 
-        $result = $this->importSqlFromFile($host_config, $context, $shell, $file);
+        $result = $this->importSqlFromFile(
+            $host_config,
+            $context,
+            $shell,
+            $file,
+            $context->get(self::DROP_DATABASE, true)
+        );
 
         $context->setResult('exitCode', $result->getExitCode());
     }
@@ -182,7 +195,7 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
      * @param HostConfig $host_config
      * @param TaskContextInterface $context
      *
-     * @throws \Phabalicious\Exception\FailedShellCommandException
+     * @throws FailedShellCommandException
      */
     public function copyFrom(HostConfig $host_config, TaskContextInterface $context)
     {
@@ -213,7 +226,7 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
 
         $result = $shell->copyFileFrom($from_shell, $from_filename, $to_filename, $context, true);
         if (!$result) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 sprintf('Could not copy file from `%s` to `%s`', $from_filename, $to_filename)
             );
         }
@@ -225,7 +238,13 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
             $host_config->getConfigName()
         ));
 
-        $result = $this->importSqlFromFile($host_config, $context, $shell, $to_filename, true);
+        $result = $this->importSqlFromFile(
+            $host_config,
+            $context,
+            $shell,
+            $to_filename,
+            $context->get(self::DROP_DATABASE, true)
+        );
         if (!$result->succeeded()) {
             $result->throwException('Could not import DB from file `' . $to_filename . '`');
         }
@@ -242,7 +261,7 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
     public function appCreate(HostConfig $host_config, TaskContextInterface $context)
     {
         if (!$current_stage = $context->get('currentStage', false)) {
-            throw new \InvalidArgumentException('Missing currentStage on context!');
+            throw new InvalidArgumentException('Missing currentStage on context!');
         }
         if ($current_stage === 'install') {
             $this->waitForDatabase($host_config, $context);
@@ -251,8 +270,8 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
     }
 
     /**
-     * @param \Phabalicious\Configuration\HostConfig $config
-     * @param \Phabalicious\Method\TaskContextInterface $context
+     * @param HostConfig $config
+     * @param TaskContextInterface $context
      */
     public function collectBackupMethods(HostConfig $config, TaskContextInterface $context)
     {
@@ -260,14 +279,14 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
     }
 
     /**
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
      * @param array $credentials
      *
      * @return mixed
-     * @throws \Phabalicious\Exception\MethodNotFoundException
-     * @throws \Phabalicious\Exception\TaskNotFoundInMethodException
-     * @throws \Phabalicious\Exception\ValidationFailedException
+     * @throws MethodNotFoundException
+     * @throws TaskNotFoundInMethodException
+     * @throws ValidationFailedException
      */
     protected function requestCredentialsAndWorkingDir(
         HostConfig $host_config,
@@ -318,17 +337,42 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
     }
 
     /**
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
      *
      * @return array
-     * @throws \Phabalicious\Exception\MethodNotFoundException
-     * @throws \Phabalicious\Exception\TaskNotFoundInMethodException
-     * @throws \Phabalicious\Exception\ValidationFailedException
+     * @throws MethodNotFoundException
+     * @throws TaskNotFoundInMethodException
+     * @throws ValidationFailedException
      */
     protected function getDatabaseCredentials(HostConfig $host_config, TaskContextInterface $context): array
     {
         $data = !empty($host_config['database']) ? $host_config['database'] : [];
         return $this->requestCredentialsAndWorkingDir($host_config, $context, $data);
+    }
+
+    /**
+     * @throws TaskNotFoundInMethodException
+     * @throws MethodNotFoundException
+     * @throws ValidationFailedException
+     */
+    public function database(HostConfig $host_config, TaskContextInterface $context)
+    {
+        $what = $context->get('what');
+        $data = $this->getDatabaseCredentials($host_config, $context);
+        $shell = $this->getShell($host_config, $context);
+
+        switch ($what) {
+            case 'install':
+                $this->install($host_config, $context);
+                break;
+
+            case 'drop':
+                $this->dropDatabase($host_config, $context, $shell, $data);
+                break;
+
+            default:
+                throw new RuntimeException(sprintf("Unknown database command `%s`", $what));
+        }
     }
 }

--- a/src/Method/DatabaseMethodInterface.php
+++ b/src/Method/DatabaseMethodInterface.php
@@ -13,8 +13,8 @@ interface DatabaseMethodInterface
     /**
      * Install a new database.
      *
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
      *
      * @return mixed
      */
@@ -23,9 +23,9 @@ interface DatabaseMethodInterface
     /**
      * Export current database into a sql file.
      *
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
-     * @param \Phabalicious\ShellProvider\ShellProviderInterface $shell
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
+     * @param ShellProviderInterface $shell
      * @param string $backup_file_name
      *
      * @return string
@@ -40,28 +40,28 @@ interface DatabaseMethodInterface
     /**
      * Import new data into database from sql dump.
      *
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
-     * @param \Phabalicious\ShellProvider\ShellProviderInterface $shell
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
+     * @param ShellProviderInterface $shell
      * @param string $file
      * @param false $drop_db
      *
-     * @return \Phabalicious\ShellProvider\CommandResult
+     * @return CommandResult
      */
     public function importSqlFromFile(
         HostConfig $host_config,
         TaskContextInterface $context,
         ShellProviderInterface $shell,
         string $file,
-        bool $drop_db = false
+        bool $drop_db
     ): CommandResult;
 
     /**
      * Drop all tables in the database.
      *
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
-     * @param \Phabalicious\ShellProvider\ShellProviderInterface $shell
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
+     * @param ShellProviderInterface $shell
      * @param array $data
      *
      * @return mixed
@@ -76,9 +76,9 @@ interface DatabaseMethodInterface
     /**
      * Check if database can handle connections.
      *
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
-     * @param \Phabalicious\ShellProvider\ShellProviderInterface $shell
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
+     * @param ShellProviderInterface $shell
      *
      * @return mixed
      */
@@ -92,7 +92,7 @@ interface DatabaseMethodInterface
      * Validate database credentials.
      *
      * @param array $data
-     * @param \Phabalicious\Validation\ValidationErrorBag $errors
+     * @param ValidationErrorBag $errors
      * @param false $validate_working_dir
      *
      * @return mixed

--- a/src/Method/DatabaseMethodInterface.php
+++ b/src/Method/DatabaseMethodInterface.php
@@ -71,7 +71,7 @@ interface DatabaseMethodInterface
         TaskContextInterface $context,
         ShellProviderInterface $shell,
         array $data
-    );
+    ): CommandResult;
 
     /**
      * Check if database can handle connections.

--- a/src/Method/MysqlMethod.php
+++ b/src/Method/MysqlMethod.php
@@ -2,8 +2,12 @@
 
 namespace Phabalicious\Method;
 
+use Exception;
 use Phabalicious\Configuration\ConfigurationService;
 use Phabalicious\Configuration\HostConfig;
+use Phabalicious\Exception\MethodNotFoundException;
+use Phabalicious\Exception\TaskNotFoundInMethodException;
+use Phabalicious\Exception\ValidationFailedException;
 use Phabalicious\ShellProvider\CommandResult;
 use Phabalicious\ShellProvider\ShellProviderInterface;
 use Phabalicious\Validation\ValidationErrorBag;
@@ -33,7 +37,7 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
     }
 
     /**
-     * @return \string[][]
+     * @return string[][]
      */
     public function getGlobalSettings(): array
     {
@@ -81,10 +85,10 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
     }
 
     /**
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function install(HostConfig $host_config, TaskContextInterface $context): ?CommandResult
     {
@@ -110,7 +114,7 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
                 $mysql_cmd[] = '-e';
                 $mysql_cmd[] = escapeshellarg($cmd);
                 return $shell->run(implode(' ', $mysql_cmd), false, true);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $context->io()
                     ->error("Could not create database, or grant privileges!");
                 $context->io()
@@ -124,9 +128,9 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
 
 
     /**
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
-     * @param \Phabalicious\ShellProvider\ShellProviderInterface $shell
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
+     * @param ShellProviderInterface $shell
      * @param array $data
      */
     public function dropDatabase(
@@ -152,9 +156,9 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
     }
 
     /**
-     * @throws \Phabalicious\Exception\TaskNotFoundInMethodException
-     * @throws \Phabalicious\Exception\MethodNotFoundException
-     * @throws \Phabalicious\Exception\ValidationFailedException
+     * @throws TaskNotFoundInMethodException
+     * @throws MethodNotFoundException
+     * @throws ValidationFailedException
      */
     public function exportSqlToFile(
         HostConfig $host_config,
@@ -198,23 +202,23 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
     }
 
     /**
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
      * @param ShellProviderInterface $shell
      * @param string $file
      * @param bool $drop_db
      *
      * @return CommandResult
-     * @throws \Phabalicious\Exception\MethodNotFoundException
-     * @throws \Phabalicious\Exception\TaskNotFoundInMethodException
-     * @throws \Phabalicious\Exception\ValidationFailedException
+     * @throws MethodNotFoundException
+     * @throws TaskNotFoundInMethodException
+     * @throws ValidationFailedException
      */
     public function importSqlFromFile(
         HostConfig $host_config,
         TaskContextInterface $context,
         ShellProviderInterface $shell,
         string $file,
-        bool $drop_db = false
+        bool $drop_db
     ): CommandResult {
         $data = $this->getDatabaseCredentials($host_config, $context);
 
@@ -240,11 +244,11 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
     }
 
     /**
-     * @param \Phabalicious\Configuration\HostConfig $host_config
-     * @param \Phabalicious\Method\TaskContextInterface $context
-     * @param \Phabalicious\ShellProvider\ShellProviderInterface $shell
+     * @param HostConfig $host_config
+     * @param TaskContextInterface $context
+     * @param ShellProviderInterface $shell
      *
-     * @return \Phabalicious\ShellProvider\CommandResult
+     * @return CommandResult
      */
     public function checkDatabaseConnection(
         HostConfig $host_config,
@@ -259,7 +263,7 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
 
     /**
      * @param array $data
-     * @param \Phabalicious\Validation\ValidationErrorBag $errors
+     * @param ValidationErrorBag $errors
      * @param false $validate_working_dir
      */
     public function validateCredentials(array $data, ValidationErrorBag $errors, bool $validate_working_dir = false)

--- a/src/Method/MysqlMethod.php
+++ b/src/Method/MysqlMethod.php
@@ -138,7 +138,7 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
         TaskContextInterface $context,
         ShellProviderInterface $shell,
         array $data
-    ) {
+    ):CommandResult {
         $this->logger->notice('Dropping all tables from database ...');
 
         $cmd = array_merge(
@@ -152,7 +152,7 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
             $this->getMysqlCommand($host_config, $context, 'mysql', $data, true)
         );
 
-        $shell->run(implode(" ", $cmd), false, true);
+        return $shell->run(implode(" ", $cmd), false, true);
     }
 
     /**

--- a/src/Method/SqliteMethod.php
+++ b/src/Method/SqliteMethod.php
@@ -74,8 +74,8 @@ class SqliteMethod extends DatabaseMethod implements MethodInterface
         TaskContextInterface $context,
         ShellProviderInterface $shell,
         array $data
-    ) {
-        $shell->run(sprintf("rm %s", $data['database']));
+    ):CommandResult {
+        return $shell->run(sprintf("rm %s", $data['database']));
     }
 
     /**

--- a/src/Method/SqliteMethod.php
+++ b/src/Method/SqliteMethod.php
@@ -146,7 +146,7 @@ class SqliteMethod extends DatabaseMethod implements MethodInterface
         TaskContextInterface $context,
         ShellProviderInterface $shell,
         string $file,
-        bool $drop_db = false
+        bool $drop_db
     ): CommandResult {
         $data = $this->getDatabaseCredentials($host_config, $context);
 


### PR DESCRIPTION
* Adds a new command `db` with two subcommands `install` and `drop` which will create a db or drop the tables of a db.
* Adds `--skip-reset` to copy-from command
* Adds `--skip-drop-db` to copy-from command
* Adds `--skip-drop-db` to restore:sql-from-file command
