### PR TITLE
Require a valid workingDir for requestCredentialsAndWorkingDir

### DIFF
--- a/src/Method/DatabaseMethod.php
+++ b/src/Method/DatabaseMethod.php
@@ -302,7 +302,7 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
         );
         $data = $cloned_context->getResult(self::DATABASE_CREDENTIALS, $credentials);
         $errors = new ValidationErrorBag();
-        $this->validateCredentials($data, $errors);
+        $this->validateCredentials($data, $errors, true);
         if ($errors->hasErrors()) {
             throw new ValidationFailedException($errors);
         }


### PR DESCRIPTION
Got a `PHP Notice:  Undefined index: workingDir in /home/mikko/projects/phabalicious/src/Method/MysqlMethod.php on line 172` with my initial attempt of using this new method.