### PR TITLE
Update isRunningAppRequired list for DatabaseMethod

### DIFF
--- a/src/Method/DatabaseMethod.php
+++ b/src/Method/DatabaseMethod.php
@@ -56,6 +56,7 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
                 'getSQLDump',
                 'copyFrom',
                 'copyFromPrepareSource',
+                'requestDatabaseCredentialsAndWorkingDir',
             ]);
     }
 


### PR DESCRIPTION
Without this k8s database methods fail with

```
  [RuntimeException]
  Could not get shell, as podForCli is empty!
```