### PR TITLE
Feature/install from sql file

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -185,7 +185,23 @@ This command will install a new installation (see the `install`-command) and aft
 **See also:**
 
 * install
+* install:from-sql-file
 * copyFrom
+
+## install:from-sql-file
+
+``` bash
+phab --config=<your-config> install:from-sql-file <sql-file-path>
+phab --config=<your-config> install:from-sql-file <sql-file-path> --skip-drop-db
+```
+This command will install an application from a local sql-file, by running the three standalone commands `install`, `restore:from-sql-file` and `reset`. It will skip any configuration-import while running install to speed things up.
+
+Passing the option `--skip-drop-db` will keep the existing DB intact, but this might result in problems while importing the SQL-file, so use with care.
+
+**See also:**
+
+* install
+* install:from
 
 ## backup
 

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -12,6 +12,7 @@ use Phabalicious\Exception\MissingDockerHostConfigException;
 use Phabalicious\Exception\ShellProviderNotFoundException;
 use Phabalicious\Exception\ValidationFailedException;
 use Phabalicious\Exception\MissingHostConfigException;
+use Phabalicious\Method\TaskContextInterface;
 use Phabalicious\ShellCompletion\FishShellCompletionContext;
 use Phabalicious\ShellProvider\ShellOptions;
 use Phabalicious\ShellProvider\ShellProviderInterface;
@@ -189,9 +190,15 @@ abstract class BaseCommand extends BaseOptionsCommand
         return $this->dockerConfig;
     }
 
-    public function runCommand(string $command, array $args, InputInterface $original_input, OutputInterface $output)
-    {
+    public function runCommand(
+        string $command,
+        array $args,
+        InputInterface $original_input,
+        OutputInterface $output,
+        TaskContextInterface $context_to_pass = null
+    ) {
         $cmd = $this->getApplication()->find($command);
+
 
         $args['command'] = $command;
 
@@ -207,6 +214,11 @@ abstract class BaseCommand extends BaseOptionsCommand
             }
         };
         $input = new ArrayInput($args);
+
+        // Pass the data of the existing context down the lane.
+        if ($context_to_pass && $cmd instanceof BaseCommand) {
+            $cmd->setContext(clone $context_to_pass);
+        }
         return $cmd->run($input, $output);
     }
 

--- a/src/Command/BaseOptionsCommand.php
+++ b/src/Command/BaseOptionsCommand.php
@@ -184,7 +184,7 @@ abstract class BaseOptionsCommand extends Command implements CompletionAwareInte
      */
     protected function createContext(InputInterface $input, OutputInterface $output, $default_arguments = [])
     {
-        $context =  $this->context ? $this->context : new TaskContext($this, $input, $output);
+        $context =  $this->context ?: new TaskContext($this, $input, $output);
         $arguments = $this->parseScriptArguments($default_arguments, $input->getOption('arguments'));
         $context->set('variables', $arguments);
         $context->set('deployArguments', $arguments);
@@ -201,5 +201,10 @@ abstract class BaseOptionsCommand extends Command implements CompletionAwareInte
     {
         assert($this->context);
         return $this->context;
+    }
+
+    protected function setContext(TaskContextInterface $context)
+    {
+        $this->context = $context;
     }
 }

--- a/src/Command/DockerCommand.php
+++ b/src/Command/DockerCommand.php
@@ -72,6 +72,21 @@ class DockerCommand extends BaseCommand
         $docker_config = $this->getDockerConfig();
         $context->set('docker_config', $docker_config);
 
+        if (!$docker_config) {
+            $docker_config_name = $this->getHostConfig()->getData()->getProperty(('docker.configuration'), false);
+            $msg = $docker_config_name
+                ? sprintf(
+                    'Host-configuration `%s` has no docker configuration named `%s`!',
+                    $this->getHostConfig()->getConfigName(),
+                    $docker_config_name
+                )
+                : sprintf(
+                    'Host-configuration `%s` has no docker-configuration!',
+                    $this->getHostConfig()->getConfigName()
+                );
+            throw new \RuntimeException($msg);
+        }
+
 
         $tasks = $input->getArgument('docker');
         if (!is_array($tasks)) {

--- a/src/Command/InstallFromSqlFileCommand.php
+++ b/src/Command/InstallFromSqlFileCommand.php
@@ -83,7 +83,8 @@ Examples:
                 '--skip-reset' => '1',
             ],
             $input,
-            $output
+            $output,
+            $context
         )) {
             return $result;
         }
@@ -95,7 +96,8 @@ Examples:
                 '--skip-drop-db' => $input->getOption('skip-drop-db'),
             ],
             $input,
-            $output
+            $output,
+            $context
         )) {
             return $result;
         }
@@ -105,7 +107,8 @@ Examples:
                 'reset',
                 [],
                 $input,
-                $output
+                $output,
+                $context
             );
         }
         return $result;

--- a/src/Command/InstallFromSqlFileCommand.php
+++ b/src/Command/InstallFromSqlFileCommand.php
@@ -1,0 +1,86 @@
+<?php /** @noinspection PhpRedundantCatchClauseInspection */
+
+namespace Phabalicious\Command;
+
+use Phabalicious\Method\DrushMethod;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class InstallFromSqlFileCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+        $this
+            ->setName('install:from-sql-file')
+            ->setDescription('Install an instance from an existing sql file')
+            ->setHelp('Runs all tasks necessary to install an instance from a sql-dump');
+        $this->addArgument(
+            'file',
+            InputArgument::REQUIRED,
+            'The file containing the sql-dump'
+        );
+        $this->addOption(
+            'skip-drop-db',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Skip dropping the db before running the import',
+            false
+        );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int|null
+     * @throws \Phabalicious\Exception\BlueprintTemplateNotFoundException
+     * @throws \Phabalicious\Exception\FabfileNotFoundException
+     * @throws \Phabalicious\Exception\FabfileNotReadableException
+     * @throws \Phabalicious\Exception\MismatchedVersionException
+     * @throws \Phabalicious\Exception\MissingDockerHostConfigException
+     * @throws \Phabalicious\Exception\ShellProviderNotFoundException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($result = parent::execute($input, $output)) {
+            return $result;
+        }
+        $context = $this->getContext();
+        // We are not interested in a config import when using drupal.
+        $context->set(DrushMethod::SKIP_CONFIGURATION_IMPORT, true);
+
+        if ($result = $this->runCommand(
+            'install',
+            [
+                '--skip-reset' => '1',
+            ],
+            $input,
+            $output
+        )) {
+            return $result;
+        }
+
+        if ($result = $this->runCommand(
+            'restore:sql-from-file',
+            [
+                'file' => $input->getArgument('file'),
+                '--skip-drop-db' => $input->getOption('skip-drop-db'),
+            ],
+            $input,
+            $output
+        )) {
+            return $result;
+        }
+
+        return $this->runCommand(
+            'reset',
+            [],
+            $input,
+            $output
+        );
+    }
+}

--- a/src/Command/InstallFromSqlFileCommand.php
+++ b/src/Command/InstallFromSqlFileCommand.php
@@ -16,8 +16,7 @@ class InstallFromSqlFileCommand extends BaseCommand
         parent::configure();
         $this
             ->setName('install:from-sql-file')
-            ->setDescription('Install an instance from an existing sql file')
-            ->setHelp('Runs all tasks necessary to install an instance from a sql-dump');
+            ->setDescription('Install an instance from an existing sql file');
         $this->addArgument(
             'file',
             InputArgument::REQUIRED,
@@ -30,6 +29,20 @@ class InstallFromSqlFileCommand extends BaseCommand
             'Skip dropping the db before running the import',
             false
         );
+        $this->setHelp('
+This command will install an application from a local sql-file, by running the
+three standalone commands <info>install</info>, <info>restore:from-sql-file</info>
+and <info>reset</info>. It will skip any configuration-import while running
+install to speed things up.
+
+Passing the option <info>skip-drop-db</info> will keep the existing DB intact,
+but this might result in problems while importing the SQL-file, so use with
+care.
+
+Examples:
+<info>phab install:from-sql-file my/sql.tgz --config mbb</info>
+
+        ');
     }
 
     /**

--- a/src/Command/OutputCommand.php
+++ b/src/Command/OutputCommand.php
@@ -64,8 +64,12 @@ class OutputCommand extends BaseCommand
         $blueprint = $input->getOption('blueprint');
         $what = strtolower($input->getOption('what'));
 
-        if (!in_array($what, ['blueprint', 'host', 'docker', 'global'])) {
-            throw new \InvalidArgumentException('Unknown option for `what`');
+        $available_options = ['blueprint', 'host', 'docker', 'global'];
+        if (!in_array($what, $available_options)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Unknown option for `what`. Allwoed values are %s',
+                '`' . implode('`, `', $available_options)  . '`'
+            ));
         }
 
         $this->readConfiguration($input);
@@ -94,7 +98,15 @@ class OutputCommand extends BaseCommand
             ];
             $title = 'Output of host-configuration `' . $config . '`';
         } elseif ($what == 'docker') {
-            $data = $this->getConfiguration()->getDockerConfig($config)->asArray();
+            try {
+                $data = $this->getConfiguration()
+                    ->getDockerConfig($config)
+                    ->asArray();
+            } catch (\Exception $e) {
+                $host_config = $this->getConfiguration()->getHostConfig($config);
+                $config = $host_config['docker']['configuration'];
+                $data = $this->getConfiguration()->getDockerConfig($config)->asArray();
+            }
             $data = [ $config => $data];
             $title = 'Output of docker-configuration `' . $config . '`';
         } elseif ($what == 'global') {

--- a/src/Command/RestoreSqlFromFileCommand.php
+++ b/src/Command/RestoreSqlFromFileCommand.php
@@ -83,13 +83,13 @@ class RestoreSqlFromFileCommand extends BaseCommand
         $context->set('source', $dest);
         $context->set(DatabaseMethod::DROP_DATABASE, !Utilities::hasBoolOptionSet($input, 'skip-drop-db'));
 
-        $context->io()->comment(sprintf('Restoring from `%s` ...', $dest));
+        $context->io()->comment(sprintf('Restoring `%s` from `%s` ...', $host_config->getConfigName(), $dest));
         $this->getMethods()->runTask('restoreSqlFromFile', $host_config, $context);
 
         $shell->run(sprintf('rm %s', $dest));
         $exitCode = $context->getResult('exitCode', 0);
         if ($exitCode == 0) {
-            $output->writeln('<info>SQL dump imported successfully</info>');
+            $context->io()->success('SQL dump imported successfully!');
         }
 
         return $exitCode;

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Phabalicious\Command;
 
+use Composer\Semver\Comparator;
 use Composer\Semver\Semver;
 use Composer\Semver\VersionParser;
 use Phabalicious\Configuration\ConfigurationService;
@@ -17,7 +18,7 @@ class SelfUpdateCommand extends BaseSelfUpdateCommand
     /**
      * @var \Phabalicious\Configuration\ConfigurationService
      */
-    private ConfigurationService $configuration;
+    private $configuration;
 
     public function __construct(ConfigurationService $configuration, $name = null)
     {
@@ -77,7 +78,7 @@ class SelfUpdateCommand extends BaseSelfUpdateCommand
 
             [$latest,] = $this->getLatestReleaseFromGithub($preview);
 
-            $update_available = ($latest && !Semver::satisfies($latest, $this->currentVersion));
+            $update_available = ($latest && Comparator::greaterThan($latest, $this->currentVersion));
             $this->configuration->getLogger()->debug(sprintf(
                 'Version-Check: current: %s, latest on remote: %s, check for preview: %s, update available: %s',
                 $version,
@@ -115,6 +116,7 @@ class SelfUpdateCommand extends BaseSelfUpdateCommand
             if ($output->isDecorated()
                 && !$output->isQuiet()
                 && !$event->getCommand()->isHidden()
+                && !$event->getCommand()->getName() !== 'self:update'
                 && !$command->getConfiguration()->isOffline()
                 && !$input->hasParameterOption(['--offline'])
                 && !$input->hasParameterOption(['--no-interaction'])

--- a/src/Configuration/ConfigurationService.php
+++ b/src/Configuration/ConfigurationService.php
@@ -379,7 +379,7 @@ class ConfigurationService
         /** @var Node $node */
         foreach ($data->findNodes($inherit_key, 1) as $node) {
             if (!$node->isArray()) {
-                $node->wrapIntoArray();
+                $node->ensureArray();
             }
             foreach ($node as $child) {
                 $item = $child->getValue();
@@ -699,9 +699,7 @@ class ConfigurationService
         if (!$data->has('needs')) {
             $data->set('needs', Node::clone($this->settings->get('needs', [])));
         }
-        if (!$data->get('needs')->isArray()) {
-            $data->get('needs')->transformToArray();
-        }
+        $data->get('needs')->ensureArray();
 
         if (!$this->getSetting('disableScripts', false)) {
             if (!$data->get('needs')->has('script')) {

--- a/src/Configuration/Storage/Node.php
+++ b/src/Configuration/Storage/Node.php
@@ -278,17 +278,12 @@ class Node implements \IteratorAggregate, \ArrayAccess
         $node->setValue($new_value);
     }
 
-    public function wrapIntoArray()
-    {
-        $this->value = [ new Node($this->value, $this->source) ];
-    }
-
     public function push($value)
     {
         $this->value[] = $value instanceof Node ? $value : new Node($value, $this->source);
     }
 
-    public function transformToArray()
+    public function ensureArray()
     {
         if (!$this->isArray()) {
             $this->value = [ new Node($this->value, $this->source)];

--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -24,6 +24,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
 
     const CONFIGURATION_EXISTS = 'configurationExists';
     const CONFIGURATION_USED = 'configurationUsed';
+    const SKIP_CONFIGURATION_IMPORT = 'skipConfigurationImport';
     const SKIP_NEXT_CONFIGURATION_IMPORT = 'skipNextConfigurationImport';
     const SETTINGS_FILE_EXISTS = 'settingsFileExists';
 
@@ -230,6 +231,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
      * @throws MissingScriptCallbackImplementation
      * @throws UnknownReplacementPatternException
      * @throws \Phabalicious\Exception\FailedShellCommandException
+     * @throws \Phabalicious\Exception\ValidationFailedException
      */
     public function reset(HostConfig $host_config, TaskContextInterface $context)
     {
@@ -448,7 +450,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
 
         // Install drupal, this can be skipped if install from configuration is
         // possible.
-        if ($context->getResult(self::CONFIGURATION_USED)) {
+        if (!$context->get(self::SKIP_CONFIGURATION_IMPORT, false) &&$context->getResult(self::CONFIGURATION_USED)) {
             $this->logger->info('Found existing and used config, installing from it ...');
 
             $install_options[] = '--existing-config';

--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -448,8 +448,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
             $install_options[] = sprintf('--db-url=%s', $db_url);
         }
 
-        // Install drupal, this can be skipped if install from configuration is
-        // possible.
+        // Install drupal from an existing configuration, if necessary.
         if (!$context->get(self::SKIP_CONFIGURATION_IMPORT, false) && $context->getResult(self::CONFIGURATION_USED)) {
             $this->logger->info('Found existing and used config, installing from it ...');
 

--- a/src/Method/DrushMethod.php
+++ b/src/Method/DrushMethod.php
@@ -450,7 +450,7 @@ class DrushMethod extends BaseMethod implements MethodInterface
 
         // Install drupal, this can be skipped if install from configuration is
         // possible.
-        if (!$context->get(self::SKIP_CONFIGURATION_IMPORT, false) &&$context->getResult(self::CONFIGURATION_USED)) {
+        if (!$context->get(self::SKIP_CONFIGURATION_IMPORT, false) && $context->getResult(self::CONFIGURATION_USED)) {
             $this->logger->info('Found existing and used config, installing from it ...');
 
             $install_options[] = '--existing-config';

--- a/src/Method/MysqlMethod.php
+++ b/src/Method/MysqlMethod.php
@@ -338,11 +338,12 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
     public static function createCredentialsUrlForDrupal(array $o): string
     {
         return sprintf(
-            '%s://%s:%s@%s/%s',
+            '%s://%s:%s@%s:%s/%s',
             $o['driver'] ?? self::METHOD_NAME,
             $o['user'],
             $o['pass'],
             $o['host'],
+            $o['port'] ?? '3306',
             $o['name']
         );
     }

--- a/src/Method/MysqlMethod.php
+++ b/src/Method/MysqlMethod.php
@@ -282,7 +282,7 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
             $this->dropDatabase($host_config, $context, $shell, $data);
         }
 
-        $this->logger->notice(sprintf('Restoring db from %s ...', $file));
+        $this->logger->info(sprintf('Restoring db from %s ...', $file));
 
         $cmd = $this->getMysqlCommand($host_config, $context, 'mysql', $data, true);
 

--- a/src/Method/TaskContext.php
+++ b/src/Method/TaskContext.php
@@ -6,7 +6,6 @@ use Phabalicious\Command\BaseOptionsCommand;
 use Phabalicious\Configuration\ConfigurationService;
 use Phabalicious\ShellProvider\CommandResult;
 use Phabalicious\ShellProvider\ShellProviderInterface;
-use Phabalicious\Utilities\PasswordManager;
 use Phabalicious\Utilities\Utilities;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,8 +30,6 @@ class TaskContext implements TaskContextInterface
     private $commandResult;
 
     private $shell;
-
-    private $passwordManager;
 
     private $io;
 
@@ -60,7 +57,7 @@ class TaskContext implements TaskContextInterface
 
     public function get(string $key, $default = null)
     {
-         return isset($this->data[$key]) ? $this->data[$key] : $default;
+         return $this->data[$key] ?? $default;
     }
 
     public function getData(): array
@@ -141,12 +138,17 @@ class TaskContext implements TaskContextInterface
 
     public function getResult($key, $default = null)
     {
-        return isset($this->result[$key]) ? $this->result[$key] : $default;
+        return $this->result[$key] ?? $default;
     }
 
     public function getResults(): array
     {
         return $this->result;
+    }
+
+    public function mergeData(TaskContextInterface $context)
+    {
+        $this->data = Utilities::mergeData($this->data, $context->getData());
     }
 
     public function mergeResults(TaskContextInterface $context)

--- a/src/Method/TaskContextInterface.php
+++ b/src/Method/TaskContextInterface.php
@@ -64,6 +64,8 @@ interface TaskContextInterface
 
     public function setShell(ShellProviderInterface $shell);
 
+    public function mergeData(TaskContextInterface $context);
+
     public function mergeResults(TaskContextInterface $context);
 
     public function askQuestion(string $string);

--- a/src/Utilities/PasswordManager.php
+++ b/src/Utilities/PasswordManager.php
@@ -21,7 +21,7 @@ class PasswordManager implements PasswordManagerInterface
     /** @var TaskContextInterface  */
     private $context;
 
-    private $passwords;
+    private $passwords = [];
 
     private $questionFactory = null;
 


### PR DESCRIPTION
Adds a new command `install:from-sql-file` which will install first the application (skipping a config import), import the sql and then run a reset afterwards.  (Fixes #223)