### PR TITLE
refactor db:query to work in more circumstances

### DIFF
--- a/src/Command/DatabaseQueryCommand.php
+++ b/src/Command/DatabaseQueryCommand.php
@@ -30,4 +30,21 @@ class DatabaseQueryCommand extends DatabaseSubCommand
     {
         return [DatabaseMethod::SQL_QUERY => 'query to execute'];
     }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->createContext($input, $output);
+        $this->getContext()->io()->comment('Querying database ...');
+
+        $result = parent::execute($input, $output);
+
+        if (!$result) {
+            $lines = $this->getContext()->getCommandResult()->getOutput();
+            $this->getContext()->io()->title("Result");
+            $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
+            foreach ($lines as $line) {
+                $output->writeln($line);
+            }
+        }
+    }
 }

--- a/src/Command/DatabaseSubCommand.php
+++ b/src/Command/DatabaseSubCommand.php
@@ -61,6 +61,10 @@ abstract class DatabaseSubCommand extends BaseCommand implements DatabaseSubComm
         $this->getMethods()
             ->runTask('database', $this->getHostConfig(), $context);
 
+        if ($this->getContext()->getCommandResult() && $this->getContext()->getCommandResult()->failed()) {
+            $this->getContext()->getCommandResult()->throwException("Query failed!");
+        }
+
         $return_code = $context->getResult('exitCode', 0);
         if ($return_code === 0) {
             $context->io()

--- a/src/Method/DatabaseMethod.php
+++ b/src/Method/DatabaseMethod.php
@@ -418,25 +418,4 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
         }
         throw new RuntimeException(sprintf("Unknown database command `%s`", $what));
     }
-
-    protected function runQuery(
-        HostConfig $host_config,
-        TaskContextInterface $context,
-        ?ShellProviderInterface $shell,
-        array $data
-    ) {
-        $tmp_file_name = tempnam($host_config->get('tmpFolder', '/tmp'), 'query');
-        $query = $context->get(self::SQL_QUERY);
-        $context->io()->comment(sprintf("Running query:\n`%s`", $query));
-        file_put_contents($tmp_file_name, $query);
-        $result = $this->importSqlFromFile(
-            $host_config,
-            $context,
-            $shell,
-            $tmp_file_name,
-            false,
-        );
-        @unlink($tmp_file_name);
-        return $result;
-    }
 }

--- a/src/Method/DatabaseMethod.php
+++ b/src/Method/DatabaseMethod.php
@@ -10,6 +10,7 @@ use Phabalicious\Exception\FailedShellCommandException;
 use Phabalicious\Exception\MethodNotFoundException;
 use Phabalicious\Exception\TaskNotFoundInMethodException;
 use Phabalicious\Exception\ValidationFailedException;
+use Phabalicious\ShellProvider\CommandResult;
 use Phabalicious\ShellProvider\ShellProviderInterface;
 use Phabalicious\Validation\ValidationErrorBag;
 use Phabalicious\Validation\ValidationErrorBagInterface;
@@ -403,7 +404,9 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
                 break;
 
             case 'query':
-                return $this->runQuery($host_config, $context, $shell, $data);
+                $result = $this->runQuery($host_config, $context, $shell, $data);
+                $context->setCommandResult($result);
+                return $result;
                 break;
 
             case 'shell':
@@ -417,5 +420,14 @@ abstract class DatabaseMethod extends BaseMethod implements DatabaseMethodInterf
                 return true;
         }
         throw new RuntimeException(sprintf("Unknown database command `%s`", $what));
+    }
+
+    public function runQuery(
+        HostConfig $host_config,
+        TaskContextInterface $context,
+        ShellProviderInterface $shell,
+        array $data
+    ): CommandResult {
+        throw new RuntimeException("Method runQuery not implemented!");
     }
 }

--- a/src/Method/DatabaseMethodInterface.php
+++ b/src/Method/DatabaseMethodInterface.php
@@ -109,4 +109,21 @@ interface DatabaseMethodInterface
     public static function createCredentialsUrlForDrupal(array $database): string;
 
     public function getShellCommand(HostConfig $host_config, TaskContextInterface $context): array;
+
+    /**
+     * Run a single query.
+     *
+     * @param \Phabalicious\Configuration\HostConfig $host_config
+     * @param \Phabalicious\Method\TaskContextInterface $context
+     * @param \Phabalicious\ShellProvider\ShellProviderInterface $shell
+     * @param array $data
+     *
+     * @return \Phabalicious\ShellProvider\CommandResult
+     */
+    public function runQuery(
+        HostConfig $host_config,
+        TaskContextInterface $context,
+        ShellProviderInterface $shell,
+        array $data
+    ): CommandResult;
 }

--- a/src/Method/MysqlMethod.php
+++ b/src/Method/MysqlMethod.php
@@ -423,7 +423,7 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
             $context,
             'mysql',
             $data,
-            false,
+            !empty($data['name']),
             ['-e', escapeshellarg($query)]
         );
         return $shell->run(implode(" ", $command), true, true);

--- a/src/Method/MysqlMethod.php
+++ b/src/Method/MysqlMethod.php
@@ -407,4 +407,25 @@ class MysqlMethod extends DatabaseMethod implements MethodInterface
         $data = $this->getDatabaseCredentials($host_config, $context);
         return $this->getMysqlCommand($host_config, $context, 'mysql', $data, true, []);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function runQuery(
+        HostConfig $host_config,
+        TaskContextInterface $context,
+        ShellProviderInterface $shell,
+        array $data
+    ): CommandResult {
+        $query = $context->get(self::SQL_QUERY);
+        $command = $this->getMysqlCommand(
+            $host_config,
+            $context,
+            'mysql',
+            $data,
+            false,
+            ['-e', escapeshellarg($query)]
+        );
+        return $shell->run(implode(" ", $command), true, true);
+    }
 }

--- a/src/ShellProvider/LocalShellProvider.php
+++ b/src/ShellProvider/LocalShellProvider.php
@@ -256,6 +256,9 @@ class LocalShellProvider extends BaseShellProvider implements ShellProviderInter
         if (preg_match('/##RESULT:(\d*)$/', $exit_code, $matches)) {
             $exit_code = intval($matches[1]);
         }
+        if ($exit_code && empty($lines)) {
+            $lines = explode("\n", trim($this->process->getErrorOutput()));
+        }
 
         $cr = new CommandResult($exit_code, $lines);
         if ($cr->failed() && !$capture_output && $throw_exception_on_error) {

--- a/src/Utilities/PasswordManager.php
+++ b/src/Utilities/PasswordManager.php
@@ -194,6 +194,8 @@ class PasswordManager implements PasswordManagerInterface
             throw new \RuntimeException("Cant resolve secrets as no valid context is available!");
         }
 
+        $exceptions = [];
+
         try {
             // Check onepassword connect ...
             if (!empty($secret_data['onePasswordVaultId']) && !empty($secret_data['onePasswordId'])) {
@@ -216,7 +218,7 @@ class PasswordManager implements PasswordManagerInterface
                 }
             }
         } catch (\Exception $e) {
-            $configuration_service->getLogger()->error($e->getMessage());
+            $exceptions[] = $e;
             // Give the user the chance to input the secret.
         }
 
@@ -233,8 +235,14 @@ class PasswordManager implements PasswordManagerInterface
                 }
             }
         } catch (\Exception $e) {
-            $configuration_service->getLogger()->error($e->getMessage());
+            $exceptions[] = $e;
             // Give the user the chance to input the secret.
+        }
+
+        if (!empty($exceptions)) {
+            foreach ($exceptions as $e) {
+                $configuration_service->getLogger()->error($e->getMessage());
+            }
         }
 
         $pw = $this->getQuestionFactory()->askAndValidate($this->getContext()->io(), $secret_data, null);

--- a/tests/MysqlMethodTest.php
+++ b/tests/MysqlMethodTest.php
@@ -130,7 +130,7 @@ class MysqlMethodTest extends PhabTestCase
         $this->backgroundProcess->setInput($input);
         $this->backgroundProcess->setTimeout(0);
         $this->backgroundProcess->start(function ($type, $buffer) {
-            fwrite(STDOUT, $buffer);
+            // fwrite(STDOUT, $buffer);
         });
         // Give the container some time to spin up
         sleep(5);
@@ -258,8 +258,8 @@ class MysqlMethodTest extends PhabTestCase
 
         $this->context->set('what', 'query');
         $this->context->set(DatabaseMethod::SQL_QUERY, $query);
-        /** @var \Phabalicious\ShellProvider\CommandResult $cmd */
-        $cmd = $this->method->database($this->hostConfig, $this->context);
+        /** @var \Phabalicious\ShellProvider\CommandResult $result */
+        $result = $this->method->database($this->hostConfig, $this->context);
 
         $this->assertEquals(0, $result->getExitCode());
         $this->assertContains($expected, $result->getOutput());
@@ -277,7 +277,7 @@ class MysqlMethodTest extends PhabTestCase
             [
                 'USE test-phabalicious; CREATE TABLE test_table(title VARCHAR(100) NOT NULL); SHOW TABLES;',
                 'test_table',
-                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Old implementation used sql-import which is not ideal, as this will freeze the app, and it worked
only when mysql was executed on your local, it broke for remote instances. Fixes https://github.com/factorial-io/phabalicious/issues/278