### PR TITLE
fix: add support for yarn.buildCommand

### DIFF
--- a/docs/blog/whats-new-in-phab-3-8.md
+++ b/docs/blog/whats-new-in-phab-3-8.md
@@ -310,7 +310,7 @@ There are two new contexts available which pigypack on the existing functionalit
 
 * `docker-image` will execute the yarn build in a docker image (see script execution contexts for configuration options)
 * `docker-image-on-docker-host` same as above, but it will be executed on the same instance where docker-commands are
-    executed, usually where your dockerConfig points to.
+    executed, usually where your dockerConfig points to. (Still experimental)
 
 ### Smaller enhancements
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -285,7 +285,7 @@ This will print all host configuration for the host `staging`.
   * `host` yarn is executed on the host, where the app is also running
   * `docker-host` is executed on the parent host, which controls docker execution
   * `docker-image` is executed in a dedicated docker-image, see script execution context for possible config options
-  * `docker-image-on-docker-host` a mixture of `docker-image` and `docker-host`
+  * `docker-image-on-docker-host` a mixture of `docker-image` and `docker-host` (still experimental)
 
 ### Configuration of the npm-method
 

--- a/src/Method/ScriptExecutionContext.php
+++ b/src/Method/ScriptExecutionContext.php
@@ -119,7 +119,7 @@ class ScriptExecutionContext
                 break;
 
             case self::DOCKER_IMAGE:
-                $working_dir = realpath($this->workingDir);
+                $working_dir = $shell->realPath($this->workingDir);
                 if (!$working_dir) {
                     throw new \RuntimeException(sprintf('Can\'t resolve working dir %s!', $this->workingDir));
                 }
@@ -140,7 +140,7 @@ class ScriptExecutionContext
                         sprintf('%d:%d', posix_getuid(), posix_getgid())
                     ),
                     '-v',
-                    sprintf('%s:/app', realpath($this->workingDir)),
+                    sprintf('%s:/app', $working_dir),
                 ];
                 if (!is_null($entrypoint = $this->getArgument('entryPoint'))) {
                     $cmd[] = sprintf('--entrypoint="%s"', $entrypoint);

--- a/src/Method/YarnMethod.php
+++ b/src/Method/YarnMethod.php
@@ -48,7 +48,7 @@ class YarnMethod extends RunCommandBaseMethod
     public function resetPrepare(HostConfig $host_config, TaskContextInterface $context)
     {
         $this->runCommand($host_config, $context, 'install');
-        $this->runCommand($host_config, $context, $host_config->get('yarnBuildCommand'));
+        $this->runCommand($host_config, $context, $host_config->get('yarn.buildCommand'));
     }
 
     public function installPrepare(HostConfig $host_config, TaskContextInterface $context)

--- a/src/Method/YarnMethod.php
+++ b/src/Method/YarnMethod.php
@@ -48,7 +48,7 @@ class YarnMethod extends RunCommandBaseMethod
     public function resetPrepare(HostConfig $host_config, TaskContextInterface $context)
     {
         $this->runCommand($host_config, $context, 'install');
-        $this->runCommand($host_config, $context, $host_config->get('yarn.buildCommand'));
+        $this->runCommand($host_config, $context, $host_config->getProperty('yarn.buildCommand'));
     }
 
     public function installPrepare(HostConfig $host_config, TaskContextInterface $context)

--- a/src/ShellProvider/BaseShellProvider.php
+++ b/src/ShellProvider/BaseShellProvider.php
@@ -292,8 +292,8 @@ abstract class BaseShellProvider implements ShellProviderInterface
         return $this->fileOperationsHandler->putFileContents($filename, $data, $context);
     }
 
-    public function realPath($filename, TaskContextInterface $context)
+    public function realPath($filename)
     {
-        return $this->fileOperationsHandler->realPath($filename, $context);
+        return $this->fileOperationsHandler->realPath($filename);
     }
 }

--- a/src/ShellProvider/DeferredFileOperations.php
+++ b/src/ShellProvider/DeferredFileOperations.php
@@ -43,7 +43,7 @@ class DeferredFileOperations implements FileOperationsInterface
         return $result;
     }
 
-    public function realPath($filename, $context)
+    public function realPath($filename)
     {
         $result = $this->shell->run(sprintf('realpath %s', $filename), true, false);
         if ($result->failed() || count($result->getOutput()) < 1) {

--- a/src/ShellProvider/FileOperationsInterface.php
+++ b/src/ShellProvider/FileOperationsInterface.php
@@ -8,5 +8,5 @@ interface FileOperationsInterface
 {
     public function getFileContents($filename, TaskContextInterface $context);
     public function putFileContents($filename, $data, TaskContextInterface $context);
-    public function realPath($filename, $context);
+    public function realPath($filename);
 }

--- a/src/ShellProvider/LocalFileOperations.php
+++ b/src/ShellProvider/LocalFileOperations.php
@@ -17,7 +17,7 @@ class LocalFileOperations implements FileOperationsInterface
         return file_put_contents($filename, $data);
     }
 
-    public function realPath($filename, $context)
+    public function realPath($filename)
     {
         return realpath($filename);
     }

--- a/src/ShellProvider/NoopFileOperations.php
+++ b/src/ShellProvider/NoopFileOperations.php
@@ -18,7 +18,7 @@ class NoopFileOperations implements FileOperationsInterface
         return false;
     }
 
-    public function realPath($filename, $context)
+    public function realPath($filename)
     {
         return $filename;
     }

--- a/src/ShellProvider/ShellProviderInterface.php
+++ b/src/ShellProvider/ShellProviderInterface.php
@@ -108,5 +108,5 @@ interface ShellProviderInterface extends LogLevelStackGetterInterface
 
     public function putFileContents($filename, $data, TaskContextInterface $context);
 
-    public function realPath($filename, TaskContextInterface $context);
+    public function realPath($filename);
 }

--- a/src/ShellProvider/UnsupportedFileOperations.php
+++ b/src/ShellProvider/UnsupportedFileOperations.php
@@ -17,7 +17,7 @@ class UnsupportedFileOperations implements FileOperationsInterface
         throw new \RuntimeException('putFileContents not supported in this context!');
     }
 
-    public function realPath($filename, $context)
+    public function realPath($filename)
     {
         throw new \RuntimeException('realPath not supported in this context!');
     }


### PR DESCRIPTION
since yarnBuildCommand has been deprecated, trying to use the suggested yarn.buildCommand leads to error because it is not implemented. This MR tries to fix that