### PR TITLE
docs: @factorial/docs update

### DIFF
--- a/.fdocs.js
+++ b/.fdocs.js
@@ -50,12 +50,12 @@ module.exports = function (defaultConfig) {
             {
                 path: "blog",
                 children: [
-                    "blog/introduction",
-                    "blog/architecture",
-                    "blog/whats-new-in-phab-3-7",
-                    "blog/how-to-use-secrets",
-                    "blog/how-to-use-phab-beta-in-parallel",
-                    "blog/whats-new-in-phab-3-8",
+                    "introduction",
+                    "architecture",
+                    "whats-new-in-phab-3-7",
+                    "how-to-use-secrets",
+                    "how-to-use-phab-beta-in-parallel",
+                    "whats-new-in-phab-3-8",
                 ],
             },
             "changelog",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.0.1",
     "@commitlint/config-conventional": "^17.0.0",
-    "@factorial/docs": "^0.2.3",
+    "@factorial/docs": "^0.3.0",
     "commitizen": "^4.2.4",
     "cz-conventional-changelog": "3.3.0",
     "cz-customizable": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,10 +445,10 @@
     "@docsearch/css" "3.2.1"
     algoliasearch "^4.0.0"
 
-"@factorial/docs@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@factorial/docs/-/docs-0.2.3.tgz#a70510bb8500463a31363417259437d10c5d4729"
-  integrity sha512-2w7ffw6t14/kIo1VXo/GWSW+83ZVysatSkxZ7sEgSVQDk3G2UiYVyjDh4EemHyjApugdlS4JBljNYP7nlILMbQ==
+"@factorial/docs@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@factorial/docs/-/docs-0.3.0.tgz#168358383b417383cc41113911ed72889cf1c0ff"
+  integrity sha512-3Ll70msqQmoIDTOBIwOgoe5VQ1zbH/qSZgTmr345dTyDkPSSPYzln3qgE+NqiovJm3K2X29Yb902UOUeN6MAnQ==
   dependencies:
     "@11ty/eleventy" "^1.0.2"
     "@11ty/eleventy-img" "^2.0.1"


### PR DESCRIPTION
I updated `@factorial/docs`, so it is not longer necessary anymore to prefix child pages with the parent page in the config file anymore. More about that here: https://www.npmjs.com/package/@factorial/docs#specifying-the-menu