### PR TITLE
feat: Add support for consuming secrets from 1Password reference links

### DIFF
--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -172,6 +172,27 @@ class SecretsTest extends PhabTestCase
         $this->assertStringNotContainsString('%secret.op-password', $output);
     }
 
+    /**
+     * @group docker
+     * @group 1password
+     */
+    public function testSecretReferenceFrom1Password()
+    {
+
+        $command = $this->application->find('output');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            '--what' => 'host',
+            '--config' => 'test1PasswordRef',
+        ));
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('iamsosecretref', $output);
+        $this->assertStringContainsString('123--iamsosecretref--321', $output);
+        $this->assertStringNotContainsString('%secret.op-password-reference', $output);
+    }
+
     public function testUnknownSecret()
     {
 

--- a/tests/assets/secret-tests/fabfile.yaml
+++ b/tests/assets/secret-tests/fabfile.yaml
@@ -10,7 +10,11 @@ secrets:
   op-password:
     question: What password is op using
     onePasswordId: n42hkvghk2onwnyugf6k2etdra
-
+  op-secret-reference:
+    question: What password is being used via 1Password secret reference?
+    # 1Password Reference is of following format.
+    # op://<vault-name>/<item-name>/[section-name/]<field-name>
+    onePasswordReference: "op://Developer/PHAB.test_reference/text"
 scripts:
   test:secrets:1:
     - echo mysql-password is //%secret.mysql-password%//
@@ -55,6 +59,12 @@ hosts:
     smtp:
       password: "%secret.op-password%"
       password_combined: "123--%secret.op-password%--321"
+
+  test1PasswordRef:
+    inheritsFrom: base
+    smtp:
+      password: "%secret.op-secret-reference%"
+      password_combined: "123--%secret.op-secret-reference%--321"
 
   testUnknownSecret:
     inheritsFrom: base


### PR DESCRIPTION
@stmh  am toying around the idea of using 1Password reference for populating secrets when 1password cli is available in the environment.