### PR TITLE
feat: add automated testing workflow for PHP 8.5

### DIFF
--- a/.github/workflows/tests-8.5.yml
+++ b/.github/workflows/tests-8.5.yml
@@ -19,9 +19,10 @@ jobs:
                   extensions: intl, zip, zlib
                   coverage: none
                   ini-values: memory_limit=1G, phar.readonly=0
+              continue-on-error: false
 
             - name: Install Project Dependencies
-              run: composer install --no-interaction --no-ansi --no-progress --no-suggest
+              run: composer install --no-interaction --no-ansi --no-progress --no-suggest --ignore-platform-reqs
 
             - name: setup git
               run: git config --global user.email "phpunit@factorial.io" && git config --global user.name "phpunit" && git config --global init.defaultBranch master

--- a/.github/workflows/tests-8.5.yml
+++ b/.github/workflows/tests-8.5.yml
@@ -32,4 +32,8 @@ jobs:
             - name: Run unit tests
               run: ./vendor/bin/phpunit tests --exclude-group docker
               env:
+                  # Allow deprecations for PHP 8.5 as dependencies need time to adapt
+                  # Deprecations from dependencies (not phabalicious code):
+                  # - curl_close() in GuzzleHTTP (transitive dependency)
+                  # - null array offset in Twig/Symfony components
                   SYMFONY_DEPRECATIONS_HELPER: weak

--- a/.github/workflows/tests-8.5.yml
+++ b/.github/workflows/tests-8.5.yml
@@ -1,0 +1,30 @@
+name: Run phpunit tests on 8.5
+
+on: [push]
+
+jobs:
+    phpunit:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 1
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: "8.5"
+                  extensions: intl, zip, zlib
+                  coverage: none
+                  ini-values: memory_limit=1G, phar.readonly=0
+
+            - name: Install Project Dependencies
+              run: composer install --no-interaction --no-ansi --no-progress --no-suggest
+
+            - name: setup git
+              run: git config --global user.email "phpunit@factorial.io" && git config --global user.name "phpunit" && git config --global init.defaultBranch master
+
+            - name: Run unit tests
+              run: ./vendor/bin/phpunit tests --exclude-group docker

--- a/.github/workflows/tests-8.5.yml
+++ b/.github/workflows/tests-8.5.yml
@@ -31,3 +31,5 @@ jobs:
 
             - name: Run unit tests
               run: ./vendor/bin/phpunit tests --exclude-group docker
+              env:
+                  SYMFONY_DEPRECATIONS_HELPER: weak

--- a/.github/workflows/tests-8.5.yml
+++ b/.github/workflows/tests-8.5.yml
@@ -16,13 +16,15 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: "8.5"
-                  extensions: intl, zip, zlib
+                  extensions: intl, zip, zlib, json, openssl, posix
                   coverage: none
                   ini-values: memory_limit=1G, phar.readonly=0
-              continue-on-error: false
+
+            - name: Verify PHP version
+              run: php -v && composer -V
 
             - name: Install Project Dependencies
-              run: composer install --no-interaction --no-ansi --no-progress --no-suggest --ignore-platform-reqs
+              run: composer install --no-interaction --no-ansi --no-progress --ignore-platform-req=php
 
             - name: setup git
               run: git config --global user.email "phpunit@factorial.io" && git config --global user.name "phpunit" && git config --global init.defaultBranch master


### PR DESCRIPTION
Add new GitHub Actions workflow to run PHPUnit tests on PHP 8.5,
following the same pattern as existing test workflows for PHP 8.2-8.4.